### PR TITLE
Repair link to Mozilla Observatory

### DIFF
--- a/tab_technical.md
+++ b/tab_technical.md
@@ -35,7 +35,10 @@ There are services out there that will analyse the HTTP response headers of othe
 
 A Mozilla project designed to help developers, system administrators, and security professionals configure their sites safely and securely.
 
-**Site:** https://mozilla.github.io/http-observatory-website/
+**Site:** https://observatory.mozilla.org/
+
+**GitHub:** https://github.com/mozilla/http-observatory/
+**GitHub:** https://github.com/mozilla/http-observatory-website/
 
 High-Tech Bridge Web Security Scanner
 


### PR DESCRIPTION
The link to Mozilla Observatory points to a staging site rather than the live production site. Fixes the site link to the production site and adds two GitHub repository links for the scanner and website repositories that support it. Fixes mozilla/http-observatory-website#224.