### PR TITLE
Handle dead and not clickable links

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,0 +1,23 @@
+# Tool "markdown-link-check" is used to validate the links
+# See https://www.npmjs.com/package/markdown-link-check
+# See https://github.com/gaurav-nelson/github-action-markdown-link-check
+name: check_validity_of_all_external_links
+on:
+  workflow_dispatch:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest  
+    steps:
+    - name: Setup Action
+      uses: actions/checkout@v2
+    - name: Run check
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: 'yes'
+        use-verbose-mode: 'yes'
+        max-depth: 10
+        file-path: '.'

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -20,4 +20,3 @@ jobs:
         use-quiet-mode: 'yes'
         use-verbose-mode: 'yes'
         max-depth: 10
-        file-path: '.'

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 title: OWASP Secure Headers Project
 level: 2
-url: "https://owasp.org/www-project-secure-headers/"
+url: https://owasp.org/www-project-secure-headers
 type: documentation
 layout: col-sidebar
 tags: headers

--- a/tab_compatibility.md
+++ b/tab_compatibility.md
@@ -32,56 +32,56 @@ _`+` = Specified version and above_
 ## References
 
 * HTTP Strict Transport Security (HSTS)
-  - https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/
-  - https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
-  - https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
-  - https://caniuse.com/#search=HSTS
+  - <https://blogs.windows.com/msedgedev/2015/06/09/http-strict-transport-security-comes-to-internet-explorer-11-on-windows-8-1-and-windows-7/>
+  - <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>
+  - <https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html>
+  - <https://caniuse.com/#search=HSTS>
 
 * X-Frame-Options
-  - https://caniuse.com/#search=X-Frame-Options
+  - <https://caniuse.com/#search=X-Frame-Options>
 
 * X-Content-Type-Options
-  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+  - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>
 
 * Content-Security-Policy
-  - https://caniuse.com/#search=Content%20Security%20Policy
+  - <https://caniuse.com/#search=Content%20Security%20Policy>
 
 * X-Permitted-Cross-Domain-Policies
-  - https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html
+  - <https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html>
 
 * Referrer-Policy
-  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+  - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>
 
 * Feature-Policy
   - Note: Depends greatly on the specific attribute
-  - https://caniuse.com/#search=Feature-Policy
-  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
+  - <https://caniuse.com/#search=Feature-Policy>
+  - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy>
 
 * Public Key Pinning Extension for HTTP (HPKP)
-  - https://caniuse.com/#search=Public%20Key%20Pinning
-  - https://groups.google.com/a/chromium.org/forum/m/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ
-  - https://www.chromestatus.com/feature/5903385005916160
+  - <https://caniuse.com/#search=Public%20Key%20Pinning>
+  - <https://groups.google.com/a/chromium.org/forum/m/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ>
+  - <https://www.chromestatus.com/feature/5903385005916160>
 
 * Expect-CT
-  - https://www.chromestatus.com/feature/5677171733430272
+  - <https://www.chromestatus.com/feature/5677171733430272>
 
 * X-XSS-Protection
-  - https://wiki.mozilla.org/Security/Features/XSS_Filter
-  - https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter/
+  - <https://wiki.mozilla.org/Security/Features/XSS_Filter>
+  - <https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter/>
   
 * Clear-Site-Data 
-  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#browser_compatibility
-  - https://www.chromestatus.com/feature/4713262029471744
-  - https://caniuse.com/?search=clear-site-data
+  - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#browser_compatibility>
+  - <https://www.chromestatus.com/feature/4713262029471744>
+  - <https://caniuse.com/?search=clear-site-data>
 
 * Cross-Origin-Embedder-Policy (COEP)
-  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#browser_compatibility
-  - https://caniuse.com/?search=Cross-Origin-Embedder-Policy
+  - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#browser_compatibility>
+  - <https://caniuse.com/?search=Cross-Origin-Embedder-Policy>
 
 * Cross-Origin-Opener-Policy (COOP)
-  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#browser_compatibility
-  - https://caniuse.com/?search=Cross-Origin-Opener-Policy
+  - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy#browser_compatibility>
+  - <https://caniuse.com/?search=Cross-Origin-Opener-Policy>
 
 * Cross-Origin-Resource-Policy (CORP)
-  - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy#browser_compatibility
-  - https://caniuse.com/?search=Cross-Origin-Resource-Policy
+  - <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy#browser_compatibility>
+  - <https://caniuse.com/?search=Cross-Origin-Resource-Policy>

--- a/tab_headers.md
+++ b/tab_headers.md
@@ -44,13 +44,13 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 
 ### References
 
-* https://tools.ietf.org/html/rfc6797
-* https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
-* https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.html
-* https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
-* https://www.chromium.org/hsts
-* https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security
-* https://raymii.org/s/tutorials/HTTP_Strict_Transport_Security_for_Apache_NGINX_and_Lighttpd.html
+* <https://tools.ietf.org/html/rfc6797>
+* <https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html>
+* <https://owasp.org/www-project-web-security-testing-guide/stable/4-Web_Application_Security_Testing/02-Configuration_and_Deployment_Management_Testing/07-Test_HTTP_Strict_Transport_Security.html>
+* <https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security>
+* <https://www.chromium.org/hsts>
+* <https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security>
+* <https://raymii.org/s/tutorials/HTTP_Strict_Transport_Security_for_Apache_NGINX_and_Lighttpd.html>
 
 ## X-Frame-Options
 
@@ -73,12 +73,12 @@ X-Frame-Options: deny
 
 ### References
 
-* https://tools.ietf.org/html/rfc7034
-* https://tools.ietf.org/html/draft-ietf-websec-x-frame-options-01
-* https://tools.ietf.org/html/draft-ietf-websec-frame-options-00
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options
-* https://owasp.org/www-community/attacks/Clickjacking
-* https://blogs.msdn.microsoft.com/ieinternals/2010/03/30/combating-clickjacking-with-x-frame-options/
+* <https://tools.ietf.org/html/rfc7034>
+* <https://tools.ietf.org/html/draft-ietf-websec-x-frame-options-01>
+* <https://tools.ietf.org/html/draft-ietf-websec-frame-options-00>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options>
+* <https://owasp.org/www-community/attacks/Clickjacking>
+* <https://blogs.msdn.microsoft.com/ieinternals/2010/03/30/combating-clickjacking-with-x-frame-options/>
 
 ## X-Content-Type-Options
 
@@ -141,12 +141,12 @@ Content-Security-Policy: script-src 'self'
 
 ### References
 
-* https://www.w3.org/TR/CSP/
-* https://developer.mozilla.org/en-US/docs/Web/Security/CSP
-* https://owasp.org/www-community/attacks/Content_Security_Policy
-* https://scotthelme.co.uk/content-security-policy-an-introduction/
-* https://report-uri.io
-* https://content-security-policy.com
+* <https://www.w3.org/TR/CSP/>
+* <https://developer.mozilla.org/en-US/docs/Web/Security/CSP>
+* <https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html>
+* <https://scotthelme.co.uk/content-security-policy-an-introduction/>
+* <https://report-uri.io>
+* <https://content-security-policy.com>
 
 ## X-Permitted-Cross-Domain-Policies
 
@@ -170,12 +170,12 @@ X-Permitted-Cross-Domain-Policies: none
 
 ### References
 
-* https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html
-* https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
-* https://www.perpetual-beta.org/weblog/security-headers.html#rule-8470-2-establish-a-cross-domain-meta-policy
-* https://danielnixon.org/http-security-headers/
-* https://rorsecurity.info/portfolio/new-http-headers-for-more-security
-* https://github.com/twitter/secureheaders/issues/88
+* <https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html>
+* <https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html>
+* <https://www.perpetual-beta.org/weblog/security-headers.html#rule-8470-2-establish-a-cross-domain-meta-policy>
+* <https://danielnixon.org/http-security-headers/>
+* <https://rorsecurity.info/portfolio/new-http-headers-for-more-security>
+* <https://github.com/twitter/secureheaders/issues/88>
 
 ## Referrer-Policy
 
@@ -202,8 +202,8 @@ Referrer-Policy: no-referrer
 
 ### References
 
-* https://www.w3.org/TR/referrer-policy/
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
+* <https://www.w3.org/TR/referrer-policy/>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>
 
 ## Clear-Site-Data
 
@@ -227,12 +227,12 @@ Clear-Site-Data: "cache","cookies","storage"
 
 ### References
 
-* https://w3c.github.io/webappsec-clear-site-data/ 
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data
-* https://caniuse.com/?search=clear-site-data
-* https://www.chromestatus.com/feature/4713262029471744
-* https://github.com/w3c/webappsec-clear-site-data
-* https://github.com/w3c/webappsec-clear-site-data/tree/master/demo
+* <https://w3c.github.io/webappsec-clear-site-data/>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data>
+* <https://caniuse.com/?search=clear-site-data>
+* <https://www.chromestatus.com/feature/4713262029471744>
+* <https://github.com/w3c/webappsec-clear-site-data>
+* <https://github.com/w3c/webappsec-clear-site-data/tree/master/demo>
 
 ## Cross-Origin-Embedder-Policy (COEP)
 
@@ -253,11 +253,11 @@ Cross-Origin-Embedder-Policy: require-corp
 
 ### References
 
-* https://html.spec.whatwg.org/multipage/origin.html#coep
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy
-* https://caniuse.com/?search=Cross-Origin-Embedder-Policy
-* https://web.dev/coop-coep/
-* https://web.dev/why-coop-coep/
+* <https://html.spec.whatwg.org/multipage/origin.html#coep>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy>
+* <https://caniuse.com/?search=Cross-Origin-Embedder-Policy>
+* <https://web.dev/coop-coep/>
+* <https://web.dev/why-coop-coep/>
 
 ## Cross-Origin-Opener-Policy (COOP)
 
@@ -279,14 +279,14 @@ Cross-Origin-Opener-Policy: same-origin
 
 ### References
 
-* https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy
-* https://caniuse.com/?search=Cross-Origin-Opener-Policy
-* https://web.dev/coop-coep/
-* https://web.dev/why-coop-coep/
-* https://github.com/xsleaks/xsleaks
-* https://portswigger.net/daily-swig/xs-leak
-* https://portswigger.net/research/xs-leak-detecting-ids-using-portal
+* <https://html.spec.whatwg.org/multipage/origin.html#cross-origin-opener-policies>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy>
+* <https://caniuse.com/?search=Cross-Origin-Opener-Policy>
+* <https://web.dev/coop-coep/>
+* <https://web.dev/why-coop-coep/>
+* <https://github.com/xsleaks/xsleaks>
+* <https://portswigger.net/daily-swig/xs-leak>
+* <https://portswigger.net/research/xs-leak-detecting-ids-using-portal>
 
 ## Cross-Origin-Resource-Policy (CORP)
 
@@ -308,10 +308,10 @@ Cross-Origin-Resource-Policy: same-origin
 
 ### References
 
-* https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header
-* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy
-* https://caniuse.com/?search=Cross-Origin-Resource-Policy
-* https://resourcepolicy.fyi/
+* <https://fetch.spec.whatwg.org/#cross-origin-resource-policy-header>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Resource-Policy>
+* <https://caniuse.com/?search=Cross-Origin-Resource-Policy>
+* <https://resourcepolicy.fyi/>
 
 ## Feature-Policy (almost deprecated)
 
@@ -356,9 +356,9 @@ Feature-Policy: vibrate 'none'; geolocation 'none'
 
 ### References
 
-* https://w3c.github.io/webappsec-feature-policy/
-* https://scotthelme.co.uk/a-new-security-header-feature-policy/
-* https://github.com/w3c/webappsec-feature-policy/blob/master/features.md
+* <https://w3c.github.io/webappsec-feature-policy/>
+* <https://scotthelme.co.uk/a-new-security-header-feature-policy/>
+* <https://github.com/w3c/webappsec-feature-policy/blob/master/features.md>
 
 ## Public Key Pinning Extension for HTTP (HPKP) (deprecated)
 
@@ -389,15 +389,15 @@ Public-Key-Pins: pin-sha256="d6qzRu9zOECb90Uez27xWltNsj0e1Md7GkYYkVoZWmM="; pin-
 
 ### References
 
-* https://tools.ietf.org/html/rfc7469
-* https://owasp.org/www-community/controls/Certificate_and_Public_Key_Pinning#HTTP_pinning
-* https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning
-* https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning
-* https://raymii.org/s/articles/HTTP_Public_Key_Pinning_Extension_HPKP.html
-* https://labs.detectify.com/2016/07/05/what-hpkp-is-but-isnt/
-* https://blog.qualys.com/ssllabs/2016/09/06/is-http-public-key-pinning-dead
-* https://scotthelme.co.uk/im-giving-up-on-hpkp/
-* https://groups.google.com/a/chromium.org/forum/m/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ
+* <https://tools.ietf.org/html/rfc7469>
+* <https://owasp.org/www-community/controls/Certificate_and_Public_Key_Pinning#HTTP_pinning>
+* <https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning>
+* <https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning>
+* <https://raymii.org/s/articles/HTTP_Public_Key_Pinning_Extension_HPKP.html>
+* <https://labs.detectify.com/2016/07/05/what-hpkp-is-but-isnt/>
+* <https://blog.qualys.com/ssllabs/2016/09/06/is-http-public-key-pinning-dead>
+* <https://scotthelme.co.uk/im-giving-up-on-hpkp/>
+* <https://groups.google.com/a/chromium.org/forum/m/#!msg/blink-dev/he9tr7p3rZ8/eNMwKPmUBAAJ>
 
 ## Expect-CT (almost deprecated)
 
@@ -424,9 +424,9 @@ Expect-CT: max-age=86400, enforce, report-uri="https://foo.example/report"
 
 ### References
 
-* https://tools.ietf.org/html/draft-ietf-httpbis-expect-ct-02
-* https://httpwg.org/http-extensions/expect-ct.html
-* https://scotthelme.co.uk/a-new-security-header-expect-ct/
+* <https://tools.ietf.org/html/draft-ietf-httpbis-expect-ct-02>
+* <https://httpwg.org/http-extensions/draft-ietf-httpbis-expect-ct.html>
+* <https://scotthelme.co.uk/a-new-security-header-expect-ct/>
 
 ## X-XSS-Protection (deprecated)
 
@@ -451,14 +451,14 @@ X-XSS-Protection: 0
 
 ### References
 
-* https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
-* https://www.chromestatus.com/feature/5021976655560704
-* https://bugzilla.mozilla.org/show_bug.cgi?id=528661
-* https://blogs.windows.com/windowsexperience/2018/07/25/announcing-windows-10-insider-preview-build-17723-and-build-18204/
-* https://github.com/zaproxy/zaproxy/issues/5849
-* https://scotthelme.co.uk/security-headers-updates/#removing-the-x-xss-protection-header
-* https://portswigger.net/daily-swig/google-chromes-xss-auditor-goes-back-to-filter-mode
-* https://owasp.org/www-community/attacks/xss/
-* https://www.virtuesecurity.com/blog/understanding-xss-auditor/
-* https://www.veracode.com/blog/2014/03/guidelines-for-setting-security-headers
-* http://zinoui.com/blog/security-http-headers#x-xss-protection
+* <https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html>
+* <https://www.chromestatus.com/feature/5021976655560704>
+* <https://bugzilla.mozilla.org/show_bug.cgi?id=528661>
+* <https://blogs.windows.com/windowsexperience/2018/07/25/announcing-windows-10-insider-preview-build-17723-and-build-18204/>
+* <https://github.com/zaproxy/zaproxy/issues/5849>
+* <https://scotthelme.co.uk/security-headers-updates/#removing-the-x-xss-protection-header>
+* <https://portswigger.net/daily-swig/google-chromes-xss-auditor-goes-back-to-filter-mode>
+* <https://owasp.org/www-community/attacks/xss/>
+* <https://www.virtuesecurity.com/blog/understanding-xss-auditor/>
+* <https://www.veracode.com/blog/2014/03/guidelines-for-setting-security-headers>
+* <http://zinoui.com/blog/security-http-headers#x-xss-protection>

--- a/tab_technical.md
+++ b/tab_technical.md
@@ -17,77 +17,71 @@ This section covers a list of tools to analyze, develop and administrate HTTP se
 
 A security scanner for HTTP response headers.
 
-**Github:** https://github.com/riramar/hsecscan
+**Github:** <https://github.com/riramar/hsecscan>
 
 ### headers
 
 Python script to get some response headers from Alexa top sites file and store in a MySQL database.
 
-**Github:** https://github.com/oshp/headers/
+**Github:** <https://github.com/oshp/headers/>
 
 ### SecurityHeaders.com
 
 There are services out there that will analyse the HTTP response headers of other sites but I also wanted to add a rating system to the results. The HTTP response headers that this site analyses provide huge levels of protection and it's important that sites deploy them. Hopefully, by providing an easy mechanism to assess them, and further information on how to deploy missing headers, we can drive up the usage of security based headers across the web.
 
-**Site:** https://securityheaders.com/
+**Site:** <https://securityheaders.com/>
 
 ### Mozilla Observatory
 
 A Mozilla project designed to help developers, system administrators, and security professionals configure their sites safely and securely.
 
-**Site:** https://observatory.mozilla.org/
+**Site:** <https://observatory.mozilla.org/>
 
-**GitHub:** https://github.com/mozilla/http-observatory/
+**GitHub:** <https://github.com/mozilla/http-observatory/>
 
-**GitHub:** https://github.com/mozilla/http-observatory-website/
-
-### High-Tech Bridge Web Security Scanner
-
-An online service that will retrieve and analyse headers syntax and proper configuration in a comprehensive way. It will be able for instance to highlight Public-Key-Pins that matches one certificate of the chain or if Content-Security-Policy contains values that could be unsafe or too permissive.
-
-**Site:** https://www.htbridge.com/websec/
+**GitHub:** <https://github.com/mozilla/http-observatory-website/>
 
 ### Check Your Headers
 
 Just another web scanner for HTTP response headers.
 
-**Site:** https://cyh.herokuapp.com/cyh
+**Site:** <https://cyh.herokuapp.com/cyh>
 
 ### Recx Security Analyser
 
 Chrome extension that allows the inspection of security aspects of a site's HTTP headers, cookies and other key security settings.
 
-**Site:** https://chrome.google.com/webstore/detail/recx-security-analyser/ljafjhbjenhgcgnikniijchkngljgjda
+**Site:** <https://chrome.google.com/webstore/detail/recx-security-analyser/ljafjhbjenhgcgnikniijchkngljgjda>
 
 ### KickOff
 
 While each project you launch may have a different feature set, they often share many of the same performance, SEO and security requirements. This tool aims to automate the process of checking your list of requirements shortly before launch or directly after a deployment.
 
-**Site:** https://github.com/frickelbruder/kickoff
+**Site:** <https://github.com/frickelbruder/kickoff>
 
 ### testssl.sh
 
 Easy to use shell script which tests not only SSL/TLS encryption but also checks common headers and analyzes those. Output is screen, JSON, CSV and HTML.
 
-**Site:** https://github.com/drwetter/testssl.sh
+**Site:** <https://github.com/drwetter/testssl.sh>
 
 ### DrHEADer
 
 DrHEADer helps with the audit of security headers received in response to a single request or a list of requests.
 
-**Site:** https://github.com/Santandersecurityresearch/DrHeader
+**Site:** <https://github.com/Santandersecurityresearch/DrHeader>
 
 ### API-Security
 
 This is a Python based API-Security framework containing ApiSecurityHeader.py script which will check the above mentioned Security response headers are present and contains the required value.
 
-**Site:** https://github.com/AmitKulkarni9/API-Security
+**Site:** <https://github.com/AmitKulkarni9/API-Security>
 
 ### Venom Test Suites
 
 Test suites for [Venom](https://github.com/ovh/venom) checking the presence and the value for the different response headers proposed by the [OWASP Secure Headers Project](https://owasp.org/www-project-secure-headers/).
 
-**GitHub:** https://gist.github.com/righettod/f63548ebd96bed82269dcc3dfea27056
+**GitHub:** <https://gist.github.com/righettod/f63548ebd96bed82269dcc3dfea27056>
 
 ## Development Libraries
 
@@ -95,86 +89,86 @@ Test suites for [Venom](https://github.com/ovh/venom) checking the presence and 
 
 Security related headers all in one gem.
 
-**Github:** https://github.com/twitter/secureheaders
+**Github:** <https://github.com/twitter/secureheaders>
 
 ### Security Header Injection Module (SHIM) (ASP.NET)
 
 SHIM is a HTTP module that provides protection for many vulnerabilities by injecting security-specific HTTP headers into ASP.NET web applications.
 
-**Site:** https://shim.codeplex.com/
+**Site:** <https://shim.codeplex.com/>
 
 ### Spring Security (Java)
 
 Spring Security’s support for adding various security headers to the response.
 
-**Site:** https://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html
+**Site:** <https://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html>
 
 ### SecureHeaders (PHP)
 
 A PHP class aiming to make the use of browser security features more accessible.
 
-**Site:** https://github.com/aidantwoods/SecureHeaders
+**Site:** <https://github.com/aidantwoods/SecureHeaders>
 
 ### rack-secure_headers (Rack)
 
 Security related HTTP headers for Rack applications.
 
-**Site:** https://github.com/frodsan/rack-secure_headers
+**Site:** <https://github.com/frodsan/rack-secure_headers>
 
 ### helmet and hood (Node.js + express)
 
-**Site:** https://github.com/helmetjs/helmet  
-**Site:** https://github.com/seanmonstar/hood
+**Site:** <https://github.com/helmetjs/helmet>
+**Site:** <https://github.com/seanmonstar/hood>
 
 ### blankie (hapi)
 
 A CSP plugin for hapi.
 
-**Site:** https://github.com/nlf/blankie
+**Site:** <https://github.com/nlf/blankie>
 
 ### NWebsec (ASP.NET)
 
 NWebsec consists of several security libraries for ASP.NET applications.
 
-**Site:** https://docs.nwebsec.com
+**Site:** <https://docs.nwebsec.com>
 
 ### django-csp + commonware; django-security (Python)
 
 django-csp + commonware; django-security.
 
-**Site:** https://github.com/mozilla/django-csp  
-**Site:** https://github.com/jsocol/commonware/  
-**Site:** https://github.com/sdelements/django-security
+**Site:** <https://github.com/mozilla/django-csp>  
+**Site:** <https://github.com/jsocol/commonware/>  
+**Site:** <https://github.com/sdelements/django-security>
 
 ### Secure (Python)
 
 Secure is a lightweight package that adds optional security headers and cookie attributes for Python web frameworks.
 
-**Site:** https://github.com/cakinney/secure
+**Site:** <https://github.com/cakinney/secure>
 
 ### secureheader (Go)
 
 Package secureheader adds some HTTP header fields widely considered to improve safety of HTTP requests.
 
-**Site:** https://github.com/kr/secureheader
+**Site:** <https://github.com/kr/secureheader>
 
 ### secure_headers (Elixir)
 
 This Plug will automatically apply several security headers to the Plug.Conn response. By design SecureHeaders will attempt to apply the most strict security policy. Although, security headers are configurable and are validated to avoid misconfiguration.
 
-**Site:** https://github.com/anotherhale/secure_headers
+**Site:** <https://github.com/anotherhale/secure_headers>
 
 ### dropwizard-web-security (Dropwizard)
 
 A bundle for applying default web security functionality to a dropwizard application.
 
-**Site:** https://github.com/palantir/dropwizard-web-security
+**Site:** <https://github.com/palantir/dropwizard-web-security>
 
 ### ember-cli-content-security-policy (Ember.js)
 
 This addon makes it easy to use Content Security Policy (CSP) in your project. It can be deployed either via a Content-Security-Policy header sent from the Ember CLI Express server, or as a meta tag in the index.html file.
 
-**Site:** https://github.com/rwjblue/ember-cli-content-security-policy/
+**Site:** <https://github.com/rwjblue/ember-cli-content-security-policy/>
 
 
 ## Operation Tools
@@ -189,5 +183,5 @@ Puppet module to enable, configure and manage secure http headers on web servers
 - NGINX
 - Lighttpd
 
-**Github:** https://github.com/amenezes/http_hardening  
-**Puppet Forge:** https://forge.puppet.com/amenezes/http_hardening
+**Github:** <https://github.com/amenezes/http_hardening>  
+**Puppet Forge:** <https://forge.puppet.com/amenezes/http_hardening>


### PR DESCRIPTION
Hi,

This PR is related to this [discussion](https://github.com/OWASP/www-project-secure-headers/issues/15#issuecomment-782067673).

Precisely it:
* Fix dead links.
* Try the `<url>` syntax in order to tackle not clickable links once converted by jekyll.