### PR TITLE
Add a new tab with extra info.

### DIFF
--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -1,6 +1,9 @@
 # Tool "markdown-link-check" is used to validate the links
 # See https://www.npmjs.com/package/markdown-link-check
 # See https://github.com/gaurav-nelson/github-action-markdown-link-check
+# For the config file:
+# See https://github.com/gaurav-nelson/github-action-markdown-link-check#custom-variables
+# See https://github.com/tcort/markdown-link-check#config-file-format
 name: check_validity_of_all_external_links
 on:
   workflow_dispatch:

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: "no"
+          use-quiet-mode: "yes"
           use-verbose-mode: "yes"
           max-depth: 10
           config-file: "markdown-link-check_config.json"

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -5,18 +5,19 @@ name: check_validity_of_all_external_links
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 jobs:
   build:
-    runs-on: ubuntu-latest  
+    runs-on: ubuntu-latest
     steps:
-    - name: Setup Action
-      uses: actions/checkout@v2
-    - name: Run check
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-        use-quiet-mode: 'yes'
-        use-verbose-mode: 'yes'
-        max-depth: 10
+      - name: Setup Action
+        uses: actions/checkout@v2
+      - name: Run check
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          max-depth: 10
+          config-file: "markdown-link-check_config.json"

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run check
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: "yes"
+          use-quiet-mode: "no"
           use-verbose-mode: "yes"
           max-depth: 10
           config-file: "markdown-link-check_config.json"

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -23,4 +23,4 @@ jobs:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"
           max-depth: 10
-          config-file: "markdown-link-check_config.jsond"
+          config-file: "./markdown-link-check_config.json"

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -23,4 +23,4 @@ jobs:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"
           max-depth: 10
-          config-file: "./markdown-link-check_config.json"
+          config-file: "markdown-link-check_config.jsond"

--- a/.github/workflows/check-external-links.yml
+++ b/.github/workflows/check-external-links.yml
@@ -23,4 +23,4 @@ jobs:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"
           max-depth: 10
-          config-file: "markdown-link-check_config.json"
+          config-file: "./markdown-link-check_config.json"

--- a/markdown-link-check_config.json
+++ b/markdown-link-check_config.json
@@ -2,7 +2,12 @@
     "httpHeaders": [{
         "urls": ["https://gf.dev"],
         "headers": {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0"
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+            "Accept-Encoding": "gzip, deflate, br",
+            "Referer": "https://www.google.com/"
         }
-    }]
+    }],
+    "timeout": "60s",
+    "retryCount": 5
 }

--- a/markdown-link-check_config.json
+++ b/markdown-link-check_config.json
@@ -8,6 +8,6 @@
             "Referer": "https://www.google.com/"
         }
     }],
-    "timeout": "60s",
+    "timeout": "20s",
     "retryCount": 5
 }

--- a/markdown-link-check_config.json
+++ b/markdown-link-check_config.json
@@ -1,0 +1,8 @@
+{
+    "httpHeaders": [{
+        "urls": ["https://gf.dev"],
+        "headers": {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0"
+        }
+    }]
+}

--- a/markdown-link-check_config.json
+++ b/markdown-link-check_config.json
@@ -1,6 +1,6 @@
 {
     "httpHeaders": [{
-        "urls": ["https://"],
+        "urls": ["https://", "http://"],
         "headers": {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",

--- a/markdown-link-check_config.json
+++ b/markdown-link-check_config.json
@@ -1,6 +1,6 @@
 {
     "httpHeaders": [{
-        "urls": ["https://gf.dev"],
+        "urls": ["https://"],
         "headers": {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:89.0) Gecko/20100101 Firefox/89.0",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",

--- a/tab_misc.md
+++ b/tab_misc.md
@@ -86,4 +86,3 @@ Sec-Fetch-User: ?1
 * <https://jub0bs.com/posts/2021-01-29-great-samesite-confusion/#are-site-and-origin-interchangeable>
 * <https://portswigger.net/daily-swig/firefox-becomes-latest-browser-to-support-fetch-metadata-request-headers>
 * <https://xsleaks.dev/docs/defenses/opt-in/fetch-metadata/>
-* <https://xdekca6g3r3gpxqd6kwm3khcd3jt7i.burpcollaborator.net>

--- a/tab_misc.md
+++ b/tab_misc.md
@@ -21,6 +21,8 @@ These headers are prefixed with `Sec-`, and hence have [forbidden header names](
 
 Source [Mozilla MDN](https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header).
 
+These headers can be leveraged to add protection measures against [XS-Leaks](https://xsleaks.dev/docs/defenses/opt-in/fetch-metadata/) attacks.
+
 #### Sec-Fetch-Dest
 
 The `Sec-Fetch-Dest` fetch metadata request header indicates the request's destination. That is the initiator of the original fetch request, which is where (and how) the fetched data will be used.
@@ -83,3 +85,4 @@ Sec-Fetch-User: ?1
 * <https://web.dev/same-site-same-origin/>
 * <https://jub0bs.com/posts/2021-01-29-great-samesite-confusion/#are-site-and-origin-interchangeable>
 * <https://portswigger.net/daily-swig/firefox-becomes-latest-browser-to-support-fetch-metadata-request-headers>
+* <https://xsleaks.dev/docs/defenses/opt-in/fetch-metadata/>

--- a/tab_misc.md
+++ b/tab_misc.md
@@ -1,0 +1,85 @@
+---
+title: misc
+displaytext: Miscellaneous
+layout: null
+tab: true
+order: 6
+tags: headers
+---
+
+# Miscellaneous
+
+This section provide extra extra useful information about HTTP Security headers.
+
+## Request headers
+
+### Fetch metadata request header
+
+A fetch metadata request header is an HTTP request header that provides additional information about the context from which the request originated. This allows the server to make decisions about whether a request should be allowed based on where the request came from and how the resource will be used .
+
+These headers are prefixed with `Sec-`, and hence have [forbidden header names](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name). As such, they *cannot be modified from JavaScript*.
+
+Source [Mozilla MDN](https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header).
+
+#### Sec-Fetch-Dest
+
+The `Sec-Fetch-Dest` fetch metadata request header indicates the request's destination. That is the initiator of the original fetch request, which is where (and how) the fetched data will be used.
+
+Possible values are detailled [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest#directives).
+
+Source [Mozilla MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest).
+
+#### Sec-Fetch-Mode
+
+The `Sec-Fetch-Mode` fetch metadata request header indicates the [mode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) of the request: **cors**, **no-cors**, **same-origin**, **navigate** or **websocket**.
+
+Broadly speaking, this allows a server to distinguish between: requests originating from a user navigating between HTML pages, and requests to load images and other resources.
+
+Possible values are detailled [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode#directives).
+
+Source [Mozilla MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode).
+
+#### Sec-Fetch-User
+
+The `Sec-Fetch-User` fetch metadata request header *is only sent for requests initiated by user activation*, and its value will always be `?1`.
+
+Source [Mozilla MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User).
+
+#### Sec-Fetch-Site
+
+The `Sec-Fetch-Site` fetch metadata request header indicates the relationship between a request initiator's origin and the origin of the requested resource.
+
+In other words, this header tells a server whether a request for a resource is coming from the same origin, the same site, a different site, or is a "user initiated" request. The server can then use this information to decide if the request should be allowed.
+
+Possible values are detailled [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site#directives).
+
+Source [Mozilla MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site).
+
+Explanation about **Site** vs **Origin** can found [here](https://web.dev/same-site-same-origin/).
+
+#### Example
+
+```
+GET /www-project-secure-headers/
+Host: owasp.org
+User-Agent: Chrome/91.0.4472.124
+Sec-Fetch-Dest: document
+Sec-Fetch-Mode: navigate
+Sec-Fetch-Site: cross-site
+Sec-Fetch-User: ?1
+```
+
+#### References
+
+* <https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header>
+* <https://caniuse.com/mdn-http_headers_sec-fetch-dest>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Dest>
+* <https://caniuse.com/mdn-http_headers_sec-fetch-mode>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Mode>
+* <https://caniuse.com/mdn-http_headers_sec-fetch-user>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-User>
+* <https://caniuse.com/mdn-http_headers_sec-fetch-site>
+* <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Fetch-Site>
+* <https://web.dev/same-site-same-origin/>
+* <https://jub0bs.com/posts/2021-01-29-great-samesite-confusion/#are-site-and-origin-interchangeable>
+* <https://portswigger.net/daily-swig/firefox-becomes-latest-browser-to-support-fetch-metadata-request-headers>

--- a/tab_misc.md
+++ b/tab_misc.md
@@ -9,7 +9,7 @@ tags: headers
 
 # Miscellaneous
 
-This section provide extra extra useful information about HTTP Security headers.
+This section provide extra useful information about HTTP Security headers.
 
 ## Request headers
 

--- a/tab_misc.md
+++ b/tab_misc.md
@@ -86,3 +86,4 @@ Sec-Fetch-User: ?1
 * <https://jub0bs.com/posts/2021-01-29-great-samesite-confusion/#are-site-and-origin-interchangeable>
 * <https://portswigger.net/daily-swig/firefox-becomes-latest-browser-to-support-fetch-metadata-request-headers>
 * <https://xsleaks.dev/docs/defenses/opt-in/fetch-metadata/>
+* <https://xdekca6g3r3gpxqd6kwm3khcd3jt7i.burpcollaborator.net>


### PR DESCRIPTION
Hi,

This PR add a new *misc* tab providing extra information about HTTP security headers in general. 

The OSHP is focused on HTTP Security **Response** headers but some **Request** header like `Sec-Fetch-*` ([source](https://developer.mozilla.org/en-US/docs/Glossary/Fetch_metadata_request_header)) can be useful to know from a defensive point of view.

I have proposed a new dedicated tab in order to not distrub the global content stucture and cause any confusion on the reader side.

Thanks in advance 😃 