### PR TITLE
Add case studies tab

### DIFF
--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -18,6 +18,7 @@ tags: headers
 * [Salesforce](https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2Fcontent%2Fb2c_commerce%2Ftopics%2Fb2c_security_best_practices%2Fb2c_declarative_security_via_http_headers.html).
 * [Black Hills Information Security](https://www.blackhillsinfosec.com/fixing-content-security-policies-with-cloudflare-workers/).
 * [Progress](https://www.progress.com/documentation/sitefinity-cms/110/predefined-security-headers-in-http-response).
+* [Bloomreach](https://documentation.bloomreach.com/14/library/concepts/security/configure-security-response-headers.html).
 
 ## Software
 

--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -1,0 +1,16 @@
+---
+title: top
+displaytext: Case Studies
+layout: null
+tab: true
+order: 7
+tags: headers
+---
+
+# Company referencing the OWASP Secure Headers Project
+
+> Feel free to contact project leaders if your company was using the project.
+
+* [Cloud.gov](https://cloud.gov/docs/management/headers/).
+* [Amazon AWS](https://docs.aws.amazon.com/whitepapers/latest/secure-content-delivery-amazon-cloudfront/improving-security-by-enabling-security-specific-headers.html).
+* [Salesforce](https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2Fcontent%2Fb2c_commerce%2Ftopics%2Fb2c_security_best_practices%2Fb2c_declarative_security_via_http_headers.html).

--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -19,6 +19,7 @@ tags: headers
 * [Black Hills Information Security](https://www.blackhillsinfosec.com/fixing-content-security-policies-with-cloudflare-workers/).
 * [Progress](https://www.progress.com/documentation/sitefinity-cms/110/predefined-security-headers-in-http-response).
 * [Bloomreach](https://documentation.bloomreach.com/14/library/concepts/security/configure-security-response-headers.html).
+* [CrashTest Security](https://crashtest-security.com/enable-security-headers/).
 
 ## Software
 

--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -14,3 +14,4 @@ tags: headers
 * [Cloud.gov](https://cloud.gov/docs/management/headers/).
 * [Amazon AWS](https://docs.aws.amazon.com/whitepapers/latest/secure-content-delivery-amazon-cloudfront/improving-security-by-enabling-security-specific-headers.html).
 * [Salesforce](https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2Fcontent%2Fb2c_commerce%2Ftopics%2Fb2c_security_best_practices%2Fb2c_declarative_security_via_http_headers.html).
+* [BLACK HILLS Information Security](https://www.blackhillsinfosec.com/fixing-content-security-policies-with-cloudflare-workers/).

--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -16,7 +16,8 @@ tags: headers
 * [Cloud.gov](https://cloud.gov/docs/management/headers/).
 * [Amazon AWS](https://docs.aws.amazon.com/whitepapers/latest/secure-content-delivery-amazon-cloudfront/improving-security-by-enabling-security-specific-headers.html).
 * [Salesforce](https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2Fcontent%2Fb2c_commerce%2Ftopics%2Fb2c_security_best_practices%2Fb2c_declarative_security_via_http_headers.html).
-* [BLACK HILLS Information Security](https://www.blackhillsinfosec.com/fixing-content-security-policies-with-cloudflare-workers/).
+* [Black Hills Information Security](https://www.blackhillsinfosec.com/fixing-content-security-policies-with-cloudflare-workers/).
+* [Progress](https://www.progress.com/documentation/sitefinity-cms/110/predefined-security-headers-in-http-response).
 
 ## Software
 

--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -7,11 +7,17 @@ order: 7
 tags: headers
 ---
 
-# Company referencing the OWASP Secure Headers Project
+# Entity referencing the OWASP Secure Headers Project
 
-> Feel free to contact project leaders if your company was using the project.
+> Feel free to contact project leaders if your company or software (open source or not) was using the project.
+
+## Company
 
 * [Cloud.gov](https://cloud.gov/docs/management/headers/).
 * [Amazon AWS](https://docs.aws.amazon.com/whitepapers/latest/secure-content-delivery-amazon-cloudfront/improving-security-by-enabling-security-specific-headers.html).
 * [Salesforce](https://documentation.b2c.commercecloud.salesforce.com/DOC4/index.jsp?topic=%2Fcom.demandware.dochelp%2Fcontent%2Fb2c_commerce%2Ftopics%2Fb2c_security_best_practices%2Fb2c_declarative_security_via_http_headers.html).
 * [BLACK HILLS Information Security](https://www.blackhillsinfosec.com/fixing-content-security-policies-with-cloudflare-workers/).
+
+## Software
+
+* [Nmap](https://github.com/nmap/nmap/blob/master/scripts/http-security-headers.nse).

--- a/tab_technical.md
+++ b/tab_technical.md
@@ -89,7 +89,7 @@ Security related headers all in one gem.
 
 Spring Security’s support for adding various security headers to the response.
 
-**Site:** <https://docs.spring.io/spring-security/site/docs/current/reference/html/headers.html>
+**Site:** <https://docs.spring.io/spring-security/reference/features/exploits/headers.html>
 
 ### SecureHeaders (PHP)
 


### PR DESCRIPTION
Hi,

This PR add a new tab listing company/software referencing the project in their documentation/website.

Google dork used to find more ref: 

`link:owasp.org/www-project-secure-headers/` 

Thanks in advance 😃 