### PR TITLE
Add issue template using GH new feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -1,0 +1,21 @@
+name: New issue
+description: Used to create new issue about the OSHP content.
+title: "[ISSUE SUMMARY]"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: issue_description
+    attributes:
+      label: Description
+      description: Please provide a summary of the issue.
+      placeholder: Typo in the header HSTS...
+    validations:
+      required: true
+  - type: textarea
+    id: issue_resources
+    attributes:
+      label: Additional resources
+      description: Please provide, when possible/applicable, useful resources helping to handle the issue.
+      placeholder: https://mydocumentation.com/article-on-problem.
+    validations:
+      required: false


### PR DESCRIPTION
Hi,

This PR add a template for new issues opened on the project content, this, using new GH feature.

Sources:
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

Thank you very much in advance 😃 