### PR TITLE
Add information about channel used for communication

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,6 +19,13 @@ We aim to publish reports on header usage stats, developments and changes, code 
 
 The OWASP Secure Headers Project is migrating to this new OWASP website. For now you can still access the old website here [https://wiki.owasp.org/index.php/OWASP_Secure_Headers_Project](https://wiki.owasp.org/index.php/OWASP_Secure_Headers_Project).
 
+## Discussions and information
+
+The following spaces are used for discussions about the project as well as spreading global information about it:
+
+* GitHub [discussions](https://github.com/OWASP/www-project-secure-headers/discussions) area.
+* Dedicated [Google group](https://groups.google.com/a/owasp.org/g/secure-headers-project).
+
 ## Contributors
 
 * [Adam Averay](https://github.com/adamaveray)
@@ -26,4 +33,4 @@ The OWASP Secure Headers Project is migrating to this new OWASP website. For now
 
 ## Licensing
 
-OWASP Secure Headers is free to use. It is licensed under the Apache 2.0 License.
+OWASP Secure Headers is free to use. It is licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Hi,

This PR add a section on the main tab to provide information about channel used for communication:

* GitHub [discussions](https://github.com/OWASP/www-project-secure-headers/discussions) area.
* Dedicated [Google group](https://groups.google.com/a/owasp.org/g/secure-headers-project).

Thank in advance 😃 