### PR TITLE
Update location info

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -10,6 +10,6 @@ body:
   attributes:
     label: Thanks for taking the time to fill out this bug report.
     description: Please kindly open your issue https://github.com/oshp/oshp-tracking/issues/new/choose
-    placeholder: :)
+    placeholder: ...
   validations:
     required: false   

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -8,7 +8,8 @@ body:
    value: Thanks for taking the time to fill out this bug report, please kindly open your issue [here](https://github.com/oshp/oshp-tracking/issues/new/choose).
 - type: textarea
   attributes:
-    label: Thanks for taking the time to fill out this bug report
+    label: Thanks for taking the time to fill out this bug report.
     description: Please kindly open your issue https://github.com/oshp/oshp-tracking/issues/new/choose
+    placeholder: :)
   validations:
     required: false   

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -3,19 +3,7 @@ description: Used to create new issue about the OSHP content.
 title: "[ISSUE SUMMARY]"
 labels: ["bug"]
 body:
-  - type: textarea
-    id: issue_description
-    attributes:
-      label: Description
-      description: Please provide a summary of the issue.
-      placeholder: Typo in the header HSTS...
-    validations:
-      required: true
-  - type: textarea
-    id: issue_resources
-    attributes:
-      label: Additional resources
-      description: Please provide, when possible/applicable, useful resources helping to handle the issue.
-      placeholder: https://mydocumentation.com/article-on-problem.
-    validations:
-      required: false
+  - type: markdown
+      attributes:
+        value: |
+          Thanks for taking the time to fill out this bug report, please kindly open your issue [here](https://github.com/oshp/oshp-tracking/issues/new/choose).

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -6,3 +6,9 @@ body:
 - type: markdown
   attributes:
    value: Thanks for taking the time to fill out this bug report, please kindly open your issue [here](https://github.com/oshp/oshp-tracking/issues/new/choose).
+- type: textarea
+  attributes:
+    label: Thanks for taking the time to fill out this bug report
+    description: Please kindly open your issue https://github.com/oshp/oshp-tracking/issues/new/choose
+  validations:
+    required: false   

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -3,7 +3,6 @@ description: Used to create new issue about the OSHP content.
 title: "[ISSUE SUMMARY]"
 labels: ["bug"]
 body:
-  - type: markdown
-      attributes:
-        value: |
-          Thanks for taking the time to fill out this bug report, please kindly open your issue [here](https://github.com/oshp/oshp-tracking/issues/new/choose).
+- type: markdown
+  attributes:
+   value: Thanks for taking the time to fill out this bug report, please kindly open your issue [here](https://github.com/oshp/oshp-tracking/issues/new/choose).

--- a/.github/ISSUE_TEMPLATE/issue_form.yml
+++ b/.github/ISSUE_TEMPLATE/issue_form.yml
@@ -5,7 +5,7 @@ labels: ["bug"]
 body:
 - type: markdown
   attributes:
-   value: Thanks for taking the time to fill out this bug report, please kindly open your issue [here](https://github.com/oshp/oshp-tracking/issues/new/choose).
+   value: 📢 Thanks for taking the time to fill out this bug report, please kindly open your issue [here](https://github.com/oshp/oshp-tracking/issues/new/choose).
 - type: textarea
   attributes:
     label: Thanks for taking the time to fill out this bug report.

--- a/index.md
+++ b/index.md
@@ -25,11 +25,11 @@ The OWASP Secure Headers Project aim to provide elements about the following asp
 * [Tools](https://owasp.org/www-project-secure-headers/#div-technical) to validate an HTTP security header configuration.
 * [Code](https://owasp.org/www-project-secure-headers/#div-technical) libraries that can be leveraged to configure recommended HTTP security headers.
 * [Statistics](https://github.com/oshp/oshp-stats) about usage of the recommended HTTP security headers.
-* [REST API](https://github.com/OWASP/www-project-secure-headers/discussions/58) allowing to obtain the recommended configuration for different web server.
+* [REST API](https://github.com/oshp/oshp-tracking/issues/2) allowing to obtain the recommended configuration for different web server.
 
 All the tools provided by the OSHP are gathered under this [GitHub organization](https://github.com/oshp/).
 
-A presentation of the project is available on the [OWASP Spotlight Youtube playlist](https://www.youtube.com/watch?v=N4F3VWQYU9E).
+A presentation of the project is available on the [OWASP Spotlight Youtube playlist](https://www.youtube.com/watch?v=N4F3VWQYU9E) as well as on the [Application Security Podcast Youtube playlist](https://www.youtube.com/watch?v=0SNU9clVhKU).
 
 ## Migration
 
@@ -52,9 +52,11 @@ We provide a [venom](https://github.com/ovh/venom) tests suite to validate an HT
 
 It is available through [this GitHub project](https://github.com/oshp/oshp-validator).
 
-## Discussions and information
+## Discussions, information and roadmap
 
-We use the GitHub [discussions](https://github.com/OWASP/www-project-secure-headers/discussions) area for discussions about the project as well as spreading global information about it.
+We use the GitHub [discussions feature](https://github.com/oshp/oshp-tracking/discussions) for discussions about the project as well as spreading global information about it.
+
+The work on the OSHP projects and associated components is tracked using the GitHub [project feature](https://github.com/orgs/oshp/projects/2).
 
 ## Contributors
 


### PR DESCRIPTION
Hi,

This PR update the location that we use to manage the discussions as well as the roadmap follow-up.

I updated the issue template to instruct users to create the issue on the new repo:

![image](https://user-images.githubusercontent.com/1573775/185656084-14c30939-a3cf-4077-9a35-f37732448ab0.png)


@riramar  Can you disable the **Discussions** feature on this repo because now we will use the **Discussions** of [this project](https://github.com/oshp/oshp-tracking/discussions) on the OSHP org.

Thanks in advance 😃 