### PR TITLE
Add temporary work around for adobe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OWASP Secure Headers Project
 
-[![OWASP Incubator](https://img.shields.io/badge/owasp-incubator-blue.svg)](https://owasp.org/projects)
+[![OWASP Lab](https://img.shields.io/badge/owasp-lab-yellow.svg)](https://owasp.org/projects)
 [![External Links Validity Check](https://github.com/OWASP/www-project-secure-headers/actions/workflows/check-external-links.yml/badge.svg?branch=master)](https://github.com/OWASP/www-project-secure-headers/actions/workflows/check-external-links.yml)
 
 The OWASP Secure Headers Project (also named OSHP) describes HTTP response headers that your application can use to increase the security of your application. Once set, these HTTP response headers can restrict modern browsers from running into easily preventable vulnerabilities. The OWASP Secure Headers Project intends to raise awareness and use of these headers.

--- a/tab_compatibility.md
+++ b/tab_compatibility.md
@@ -17,7 +17,7 @@ tags: headers
 | X-Frame-Options                              | <https://caniuse.com/x-frame-options> |
 | X-Content-Type-Options                       | <https://caniuse.com/mdn-http_headers_x-content-type-options>|
 | Content-Security-Policy                      | <https://caniuse.com/?search=content-security-policy> |
-| X-Permitted-Cross-Domain-Policies            | <https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html>                |
+| X-Permitted-Cross-Domain-Policies            | <!-- markdown-link-check-disable --><https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html><!-- markdown-link-check-disable -->                |
 | Referrer-Policy                              | <https://caniuse.com/referrer-policy>  |
 | Feature-Policy                               | <https://caniuse.com/feature-policy>  |
 | HTTP Public-Key-Pins (HPKP)                  | <https://caniuse.com/publickeypinning>  |

--- a/tab_headers.md
+++ b/tab_headers.md
@@ -190,7 +190,9 @@ X-Permitted-Cross-Domain-Policies: none
 
 ### References
 
+<!-- markdown-link-check-disable -->
 * <https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html>
+<!-- markdown-link-check-disable -->
 * <https://danielnixon.org/http-security-headers/>
 * <https://rorsecurity.info/portfolio/new-http-headers-for-more-security>
 * <https://github.com/twitter/secureheaders/issues/88>

--- a/tab_headers.md
+++ b/tab_headers.md
@@ -190,7 +190,9 @@ X-Permitted-Cross-Domain-Policies: none
 
 ### References
 
-* <!-- markdown-link-check-disable --><https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html><!-- markdown-link-check-disable -->
+<!-- markdown-link-check-disable -->
+* <https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html>
+<!-- markdown-link-check-disable -->
 * <https://danielnixon.org/http-security-headers/>
 * <https://rorsecurity.info/portfolio/new-http-headers-for-more-security>
 * <https://github.com/twitter/secureheaders/issues/88>

--- a/tab_headers.md
+++ b/tab_headers.md
@@ -190,9 +190,7 @@ X-Permitted-Cross-Domain-Policies: none
 
 ### References
 
-<!-- markdown-link-check-disable -->
-* <https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html>
-<!-- markdown-link-check-disable -->
+* <!-- markdown-link-check-disable --><https://www.adobe.com/devnet-docs/acrobatetk/tools/AppSec/xdomain.html><!-- markdown-link-check-disable -->
 * <https://danielnixon.org/http-security-headers/>
 * <https://rorsecurity.info/portfolio/new-http-headers-for-more-security>
 * <https://github.com/twitter/secureheaders/issues/88>


### PR DESCRIPTION
This PR add a temporary work round for the [adobe link validation problem](https://github.com/oshp/oshp-tracking/issues/8) and update badge in missed location.