### PR TITLE
Remove child-src from Content-Security-Policy

### DIFF
--- a/tab_bestpractices.md
+++ b/tab_bestpractices.md
@@ -34,7 +34,7 @@ The following section propose a configuration for the [actively supported and wo
 | Strict-Transport-Security                    | `max-age=31536000 ; includeSubDomains` |
 | X-Frame-Options                              | `deny` |
 | X-Content-Type-Options                       | `nosniff` |
-| Content-Security-Policy                      | `default-src 'self'; object-src 'none'; child-src 'self'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content` |
+| Content-Security-Policy                      | `default-src 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content` |
 | X-Permitted-Cross-Domain-Policies            | `none` |
 | Referrer-Policy                              | `no-referrer`  |
 | Clear-Site-Data                              | `"cache","cookies","storage"` |


### PR DESCRIPTION
Since default-src is 'self', it seems that child-src 'self' is redundant.