### PR TITLE
Add monitoring dashboard for referenced GitHub projects in the tab named Technical

### DIFF
--- a/.github/workflows/monitoring-technical-references-generate-dashboard.yml
+++ b/.github/workflows/monitoring-technical-references-generate-dashboard.yml
@@ -1,0 +1,27 @@
+name: update_monitoring_technical_references_dashboard
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - 'tab_technical.md' 
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run generation of the dashboard
+      run: |
+        cd ci; python monitoring_technical_references_generate_dashboard.py "${{ secrets.GITHUB_TOKEN }}"
+    - name: Set up Git user
+      run: git config --global user.email "gha@github.com"; git config --global user.name "GHActionBot"
+    - name: Commit update
+      run: git commit -am "Sync monitoring technical references dashboard file"; git push
+

--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ Content editing is done with [Visual Studio Code](https://code.visualstudio.com/
 
 A [workspace file](project.code-workspace) is provided with [recommended extensions](.vscode/extensions.json).
 
-## Generated content
+## Automatically generated content
 
-The folder [ci](ci) contains materials to generate the both JSON files containing the header recommended to add and remove.
+The folder [ci](ci) (**CI** for **C**ontinuous **I**ntegration) contains materials to generate the following content.
 
-Generation is performed by this GitHub action [workflow](.github/workflows/headers-generate-json-files.yml) everytime the file [tab_bestpractices.md](tab_bestpractices.md) is modified.
+📝 Generate the both JSON files containing the header recommended to add and remove:
+
+* Generation is performed by this GitHub action [workflow](.github/workflows/headers-generate-json-files.yml) everytime the file [tab_bestpractices.md](tab_bestpractices.md) is modified.
+
+📝  Generate the [markdown file](monitoring_technical_references_dashboard.md) with the update health state of all GitHub repositories mentioned in the tab named **[Technical](tab_technical.md)**:
+
+* Generation is performed by this GitHub action [workflow](.github/workflows/monitoring-technical-references-generate-dashboard.yml) everytime the file [tab_technical.md](tab_technical.md) is modified.
 
 ## Contributors
 
@@ -44,4 +50,4 @@ Generation is performed by this GitHub action [workflow](.github/workflows/heade
 
 ## Licensing
 
-OWASP Secure Headers Project is free to use. It is licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).
+**OWASP Secure Headers Project** is free to use. It is licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,7 @@ remote_theme: "owasp/www--site-theme@main"
 # core files/folders to exclude
 exclude:
   - README.md
+  - monitoring_technical_references_dashboard.md
 
 plugins:
- - jekyll-include-cache-0.2.0
+  - jekyll-include-cache-0.2.0

--- a/ci/headers_add.json
+++ b/ci/headers_add.json
@@ -1,5 +1,5 @@
 {
-  "last_update_utc": "2022-09-24 15:15:51",
+  "last_update_utc": "2022-09-24 15:23:18",
   "headers": [
     {
       "name": "Cache-Control",

--- a/ci/headers_remove.json
+++ b/ci/headers_remove.json
@@ -1,5 +1,5 @@
 {
-  "last_update_utc": "2022-09-24 15:15:51",
+  "last_update_utc": "2022-09-24 15:23:18",
   "headers": [
     "Liferay-Portal",
     "Powered-By",

--- a/ci/monitoring_technical_references_generate_dashboard.py
+++ b/ci/monitoring_technical_references_generate_dashboard.py
@@ -1,0 +1,114 @@
+"""
+Utility script to generate a markdown file with the update health state of all GitHub repositories mentioned in the tab named "Technical".
+
+The goal is to allow detection of old and dead projects.
+
+Sources:
+    https://thispointer.com/python-get-difference-between-two-dates-in-months/
+    https://docs.github.com/en/rest/repos/repos#get-a-repository
+
+Try to not use any external dependency to stay the more portable possible.
+"""
+import json
+import re
+import sys
+import urllib.request
+from datetime import datetime
+
+# Constants
+EXECUTION_DATETIME_UTC = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+DEFAULT_ENCODING = "utf-8"
+SOURCE_MD_FILE = "../tab_technical.md"
+DASHBOARD_MD_FILE = "../monitoring_technical_references_dashboard.md"
+DASHBOARD_MD_FILE_TEMPLATE = f"""
+# Technical References Dashboard
+
+> :timer_clock: Last verification (UTC): {EXECUTION_DATETIME_UTC}
+
+## GitHub repositories health status
+
+:speech_balloon: **Status icon legends:**
+
+* :green_circle: Updated within the last **12 months** from the date of verification.
+* :orange_circle: Updated within the last **24 months** from the date of verification.
+* :red_circle: Not updated for **more than 24 months** from the date of verification.
+
+%s
+
+"""
+
+
+def determine_health_state(repo_updated_datetime):
+    # Format: 2022-09-14T13:40:24Z
+    # Keep only the date part
+    start_date = datetime.strptime(repo_updated_datetime.split("T")[0], "%Y-%m-%d")
+    end_date = datetime.now()
+    diff_months = ((end_date.year - start_date.year) * 12) + (end_date.month - start_date.month)
+    if diff_months <= 12:
+        health_state_icon = ":green_circle:"
+    elif diff_months <= 24:
+        health_state_icon = ":orange_circle:"
+    else:
+        health_state_icon = ":red_circle:"
+    return (diff_months, health_state_icon)
+
+
+def extract_updated_datetime(github_repo_url, github_access_token):
+    # Extract the repo owner and project name from the repo url
+    parts = github_repo_url.strip(' \r\n\t').split("/")
+    repo_owner = parts[3]
+    project_name = parts[4]
+    # Get the info of the repo using the GitHub API
+    api_url = f"https://api.github.com/repos/{repo_owner}/{project_name}"
+    request = urllib.request.Request(url=api_url, method="GET")
+    if github_access_token is not None:
+        request.add_header("Authorization", f"Bearer {github_access_token}")
+    with urllib.request.urlopen(request) as f:
+        repo_info = json.loads(f.read().decode(DEFAULT_ENCODING))
+    # Return the updated date attribute
+    # Format: 2022-09-14T13:40:24Z
+    return repo_info["updated_at"]
+
+
+def extract_github_repositories_url():
+    github_repositories_url_collection = []
+    expr = r'<https://github.com/.*>'
+    with open(SOURCE_MD_FILE, mode="r", encoding=DEFAULT_ENCODING) as f:
+        content = f.read()
+    repos = re.findall(expr, content)
+    for repo in repos:
+        github_repositories_url_collection.append(repo.strip(' <>'))
+    github_repositories_url_collection.sort()
+    return github_repositories_url_collection
+
+
+def generate_md_table(github_repositories_url_collection, github_access_token):
+    table_md = "| Last update | Status | Repository |\n| --- | --- | --- |\n"
+    lines = []
+    for repo in github_repositories_url_collection:
+        updated_datetime = extract_updated_datetime(repo, github_access_token)
+        health_state = determine_health_state(updated_datetime)
+        repo_name = repo.replace("https://github.com/", "")
+        lines.append(f"| `{updated_datetime}` ({health_state[0]} months ago) | {health_state[1]} | [{repo_name}]({repo}) |")
+    lines.sort()
+    table_md += "\n".join(lines)
+    return table_md
+
+
+if __name__ == "__main__":
+    github_access_token = None
+    if len(sys.argv) == 2:
+        print("[i] GitHub access token provided.")
+        github_access_token = sys.argv[1]
+    else:
+        print("[i] No GitHub access token provided.")
+    print("[+] Extract GitHub repositories url...")
+    repos = extract_github_repositories_url()
+    print(f"{len(repos)} repos.")
+    print("[+] Generate MD table...")
+    table_md = generate_md_table(repos, github_access_token)
+    print("[+] Update dashboard MD file...")
+    dashboard_content = DASHBOARD_MD_FILE_TEMPLATE % table_md
+    with open(DASHBOARD_MD_FILE, mode="w", encoding=DEFAULT_ENCODING) as f:
+        f.write(dashboard_content)
+    print(f"[V] File '{DASHBOARD_MD_FILE}' updated.")

--- a/ci/monitoring_technical_references_generate_dashboard.py
+++ b/ci/monitoring_technical_references_generate_dashboard.py
@@ -27,6 +27,8 @@ DASHBOARD_MD_FILE_TEMPLATE = f"""
 
 ## GitHub repositories health status
 
+Provides a quick visual status on the health status (whether they are updated or not) of the referenced GitHub projects in the tab named **Technical**.
+
 :speech_balloon: **Status icon legends:**
 
 * :green_circle: Updated within the last **12 months** from the date of verification.

--- a/index.md
+++ b/index.md
@@ -53,6 +53,17 @@ We provide a [venom](https://github.com/ovh/venom) tests suite to validate an HT
 
 It is available through [this GitHub project](https://github.com/oshp/oshp-validator).
 
+## Headers reference files
+
+As mentioned in previous sections, we provide the collection of HTTP response security headers to add as well as HTTP response headers to remove, both in table form.
+
+💡 Additionally, we provide this information as two JSON files to enable automation in the context of a provisioning workflow:
+
+* Collection of [HTTP response security headers to add](ci/headers_add.json).
+* Collection of [HTTP response headers to remove](ci/headers_remove.json).
+
+📡 These json files are automatically updated.
+
 ## Discussions, information and roadmap
 
 We use the GitHub [discussions feature](https://github.com/oshp/oshp-tracking/discussions) for discussions about the project as well as spreading global information about it.

--- a/monitoring_technical_references_dashboard.md
+++ b/monitoring_technical_references_dashboard.md
@@ -1,0 +1,1 @@
+INIT CONTENT

--- a/tab_technical.md
+++ b/tab_technical.md
@@ -34,12 +34,6 @@ A humble, and fast, security-oriented HTTP headers analyzer.
 
 **GitHub:** <https://github.com/rfc-st/humble>
 
-### headers
-
-Python script to get some response headers from Alexa top sites files and store in a MySQL database.
-
-**GitHub:** <https://github.com/oshp/headers/>
-
 ### SecurityHeaders.com
 
 There are services out there that will analyze the HTTP response headers of other sites but I also wanted to add a rating system to the results. The HTTP response headers that this site analysis provides huge levels of protection and it's important that sites deploy them. Hopefully, by providing an easy mechanism to assess them, and further information on how to deploy missing headers, we can drive up the usage of security based headers across the web.


### PR DESCRIPTION
Hi,

This PR add the automated generation of a monitoring dashboard for referenced GitHub projects in the tab named **Technical** each time the file **tab_technical.md** is modified.

The goal is to allow detection of old and dead projects.

It also add information about the reference JSON files added few weeks ago to the project.

Thanks in advance 😃 