### PR TITLE
Update badge with reference url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OWASP Secure Headers Project
 
-[![OWASP Lab](https://img.shields.io/badge/owasp-lab-yellow.svg)](https://owasp.org/projects)
+[![OWASP Lab](https://img.shields.io/badge/owasp-lab%20project-f7b73c.svg)](https://www.owasp.org/projects)
 [![External Links Validity Check](https://github.com/OWASP/www-project-secure-headers/actions/workflows/check-external-links.yml/badge.svg?branch=master)](https://github.com/OWASP/www-project-secure-headers/actions/workflows/check-external-links.yml)
 [![Update headers reference JSON files](https://github.com/OWASP/www-project-secure-headers/actions/workflows/headers-generate-json-files.yml/badge.svg?branch=master)](https://github.com/OWASP/www-project-secure-headers/actions/workflows/headers-generate-json-files.yml)
 [![Update monitoring technical references dashboard](https://github.com/OWASP/www-project-secure-headers/actions/workflows/monitoring-technical-references-generate-dashboard.yml/badge.svg?branch=master)](https://github.com/OWASP/www-project-secure-headers/actions/workflows/monitoring-technical-references-generate-dashboard.yml)

--- a/index.md
+++ b/index.md
@@ -9,7 +9,7 @@ tags: headers
 
 ## Introduction
 
-[![OWASP Lab](https://img.shields.io/badge/owasp-lab-yellow.svg)](https://owasp.org/projects)
+[![OWASP Lab](https://img.shields.io/badge/owasp-lab%20project-f7b73c.svg)](https://www.owasp.org/projects)
 [![External Links Validity Check](https://github.com/OWASP/www-project-secure-headers/actions/workflows/check-external-links.yml/badge.svg?branch=master)](https://github.com/OWASP/www-project-secure-headers/actions/workflows/check-external-links.yml)
 [![Update headers reference JSON files](https://github.com/OWASP/www-project-secure-headers/actions/workflows/headers-generate-json-files.yml/badge.svg?branch=master)](https://github.com/OWASP/www-project-secure-headers/actions/workflows/headers-generate-json-files.yml)
 [![Update monitoring technical references dashboard](https://github.com/OWASP/www-project-secure-headers/actions/workflows/monitoring-technical-references-generate-dashboard.yml/badge.svg?branch=master)](https://github.com/OWASP/www-project-secure-headers/actions/workflows/monitoring-technical-references-generate-dashboard.yml)

--- a/info.md
+++ b/info.md
@@ -1,2 +1,16 @@
-### Code Repository
-* [Project GitHub Organization](https://github.com/oshp/)
+### Project Information
+
+* <i class="fas fa-flask fa-3x" style="color:#f7b73c"></i> <span style="font-size: 1.3em;">Lab Project</span>
+
+#### Classification
+
+* <i class="fas fa-file-alt fa-3x" style="color:#233e81;"></i> Documentation
+
+#### Audience
+
+* <i class="fas fa-toolbox fa-3x" style="color:#233e81;"></i> Builder
+* <i class="fas fa-shield-alt fa-3x" style="color:#233e81;"></i> Defender
+
+### Project GitHub Organization
+
+* 💻 [OSHP](https://github.com/oshp/)


### PR DESCRIPTION
Hi,

This PR update the project status badge to the reference one specified below:

- https://github.com/OWASP/www-committee-project/blob/master/tab_resources.md
- https://owasp.org/www-committee-project/#div-resources

![image](https://user-images.githubusercontent.com/1573775/195019840-a3faf1ef-9cd6-499b-b729-06ce132614da.png)

![image](https://user-images.githubusercontent.com/1573775/195024216-8088cc34-2cdd-47c7-83a3-a05f3fd0ba11.png)

![image](https://user-images.githubusercontent.com/1573775/195024298-f5c26556-74c8-4132-ab96-64ba13e76e00.png)

Thanks in advance 😃 