### PR TITLE
Remove REST API line and rearrange content

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,6 @@ HTTP headers are well known and also despised. Seeking a balance between usabili
 * [Tools](https://owasp.org/www-project-secure-headers/#div-technical) to validate an HTTP security header configuration.
 * [Code](https://owasp.org/www-project-secure-headers/#div-technical) libraries that can be leveraged to configure recommended HTTP security headers.
 * [Statistics](https://github.com/oshp/oshp-stats) about usage of the recommended HTTP security headers.
-* [REST API](https://github.com/oshp/oshp-tracking/issues/2) allowing to obtain the recommended configuration for different web server.
 
 🏭 All the tools provided by the OSHP are gathered under this [GitHub organization](https://github.com/oshp/).
 

--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -3,7 +3,7 @@ title: casestudies
 displaytext: Case Studies
 layout: null
 tab: true
-order: 7
+order: 8
 tags: headers
 ---
 

--- a/tab_codesnippets.md
+++ b/tab_codesnippets.md
@@ -1,0 +1,96 @@
+---
+title: codesnippets
+displaytext: Code Snippets
+layout: null
+tab: true
+order: 7
+tags: headers
+---
+
+# Code Snippets
+
+🧾 The following code collection provides various code snippets to make working with HTTP security headers easier.
+
+* [Convert a Permissions-Policy back to Feature-Policy](#convert-a-permissions-policy-back-to-feature-policy)
+* [Test locally a Content-Security-Policy for weaknesses](#test-locally-a-content-security-policy-for-weaknesses)
+
+## Convert a Permissions-Policy back to Feature-Policy
+
+As the [Permissions-Policy](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md) header is still in development and is [not yet well supported](https://caniuse.com/permissions-policy), it can be interesting to use the two formats to increase the coverage of browsers according to their support level for **Permissions-Policy** and **[Feature-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)** policy headers.
+
+The following _python3_ code snippet can be useful to achieve such conversion.
+
+📑 Source for the conversion rules was this [one](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#appendix-big-changes-since-this-was-called-feature-policy).
+
+💻 Code snippet:
+
+```python
+permissions_policy = 'fullscreen=(), geolocation=(self "https://game.com" "https://map.example.com"), gyroscope=(self), usb=*'
+feature_policy_directives = []
+# Collect directives
+permissions_policy_directives = permissions_policy.split(",")
+# Process each directive
+for permissions_policy_directive in permissions_policy_directives:
+    # Remove leading and trailing spaces
+    directive = permissions_policy_directive.strip(" ")
+    # Remove all double quotes
+    directive = directive.replace("\"", "")
+    # Replace disabling expression () by the corresponding one in Feature-Policy
+    directive = directive.replace("()", "'none'")
+    # Quote keywords: self
+    directive = directive.replace("self", "'self'")
+    # Replace the equals affectation character by a space
+    directive = directive.replace("=", " ")
+    # Remove parenthesis
+    directive = directive.replace("(", "").replace(")", "")
+    # Add the current directive to the collection
+    feature_policy_directives.append(directive)
+# Convert the collection of directives to a string with ; as directives separator
+feature_policy = "; ".join(feature_policy_directives)
+print(feature_policy)
+```
+
+💻 Execution example:
+
+```shell
+$ python code.py
+fullscreen 'none'; geolocation 'self' https://game.com https://map.example.com; gyroscope 'self'; usb *
+```
+
+## Test locally a Content-Security-Policy for weaknesses
+
+It can be interesting to validate locally a **Content-Security-Policy** for presence of weaknesses prior to apply it on deployed web applications.
+
+The following _JavaScript_ code snippet can be useful to achieve such validation by leveraging the [csp-evaluator](https://github.com/google/csp-evaluator) NPM module provided by Google.
+
+💻 Code snippet:
+
+```javascript
+import {CspEvaluator} from "csp_evaluator/dist/evaluator.js";
+import {CspParser} from "csp_evaluator/dist/parser.js";
+
+const args = process.argv.slice(2)
+if(args.length == 0){
+    console.error("[!] Missing CSP!");
+}else{
+    const csp = args[0]
+    console.info(`[+] CSP to evaluate:\n${csp}`);
+    const parsed = new CspParser(csp).csp;
+    console.info(`[+] Evaluation results:`);
+    const results = new CspEvaluator(parsed).evaluate();
+    results.forEach(elt => {
+        let info = `[Directive '${elt.directive}' - Severity ${elt.severity}]: ${elt.description}`;
+        console.info(info);
+    });
+}
+```
+
+💻 Execution example:
+
+```shell
+$ node code.js "default-src 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content"
+[+] CSP to evaluate:
+default-src 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
+[+] Evaluation results:
+[Directive 'default-src' - Severity 50]: 'self' can be problematic if you host JSONP, Angular or user uploaded files.
+```

--- a/tab_codesnippets.md
+++ b/tab_codesnippets.md
@@ -13,6 +13,7 @@ tags: headers
 
 * [Convert a Permissions-Policy back to Feature-Policy](#convert-a-permissions-policy-back-to-feature-policy)
 * [Test locally a Content-Security-Policy for weaknesses](#test-locally-a-content-security-policy-for-weaknesses)
+* [Generate configuration code using the OSHP headers reference files](#generate-configuration-code-using-the-oshp-headers-reference-files)
 
 ## Convert a Permissions-Policy back to Feature-Policy
 
@@ -93,4 +94,19 @@ $ node code.js "default-src 'self'; object-src 'none'; frame-ancestors 'none'; u
 default-src 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
 [+] Evaluation results:
 [Directive 'default-src' - Severity 50]: 'self' can be problematic if you host JSONP, Angular or user uploaded files.
+```
+
+## Generate configuration code using the OSHP headers reference files
+
+The following _bash_ code snippet, leveraging [jq](https://stedolan.github.io/jq/), can be used to generate configuration code using the OSHP headers reference files.
+
+💻 Code snippet and execution example:
+
+```shell
+# Generate the Nginx collection of instructions to add the recommanded HTTP response headers
+$ curl -sk https://owasp.org/www-project-secure-headers/ci/headers_add.json | jq -r '.headers[] | "add_header \(.name) \(.value);"'
+add_header Cache-Control no-store, max-age=0;
+add_header Clear-Site-Data "cache","cookies","storage";
+add_header Cross-Origin-Embedder-Policy require-corp;
+...
 ```

--- a/tab_technical.md
+++ b/tab_technical.md
@@ -9,12 +9,21 @@ tags: headers
 
 # Technical Resources
 
-This section provides a list of tools as well as documents to understand, analyze, develop and administer HTTP secure headers to help achieving more secure and trustworthy web systems.
+🏗 This section provides a list of tools as well as documents to understand, analyze, develop and administer HTTP secure headers to help achieving more secure and trustworthy web systems.
 
 * 📺 [Presentations](#presentations)
 * 🏭 [Analysis Tools](#analysis-tools)
 * 👩‍💻 [Development Libraries](#development-libraries)
-* 💡 [Miscellaneous Hints](#miscellaneous-hints)
+  * [DotNet](#dotnet)
+  * [Go](#go)
+  * [HAPI](#hapi)
+  * [Java](#java)
+  * [NodeJS](#nodejs)
+  * [PHP](#php)
+  * [Python](#python)
+  * [RACK](#rack)
+  * [Ruby](#ruby)
+  * [Rust](#rust)
 
 ## Presentations
 
@@ -90,7 +99,7 @@ Spring Security’s support for adding various security headers to the response.
 
 **Site:** <https://docs.spring.io/spring-security/reference/features/exploits/headers.html>
 
-### .NET
+### DotNet
 
 #### NWebsec
 
@@ -187,86 +196,3 @@ HTTP security middleware for Go(lang) inspired by HelmetJS.
 Best-practice OWASP HTTP response headers for Rust.
 
 **Site:** <https://docs.rs/crate/owasp-headers/latest>
-
-## Miscellaneous Hints
-
-### Convert a Permissions-Policy back to Feature-Policy
-
-As the [Permissions-Policy](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md) header is still in development and is [not yet well supported](https://caniuse.com/permissions-policy), it can be interesting to use the two formats to increase the coverage of browsers according to their support level for **Permissions-Policy** and **[Feature-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy)** policy headers.
-
-The following _python3_ code snippet can be useful to achieve such conversion.
-
-📑 Source for the conversion rules was this [one](https://github.com/w3c/webappsec-permissions-policy/blob/main/permissions-policy-explainer.md#appendix-big-changes-since-this-was-called-feature-policy).
-
-💻 Code snippet:
-
-```python
-permissions_policy = 'fullscreen=(), geolocation=(self "https://game.com" "https://map.example.com"), gyroscope=(self), usb=*'
-feature_policy_directives = []
-# Collect directives
-permissions_policy_directives = permissions_policy.split(",")
-# Process each directive
-for permissions_policy_directive in permissions_policy_directives:
-    # Remove leading and trailing spaces
-    directive = permissions_policy_directive.strip(" ")
-    # Remove all double quotes
-    directive = directive.replace("\"", "")
-    # Replace disabling expression () by the corresponding one in Feature-Policy
-    directive = directive.replace("()", "'none'")
-    # Quote keywords: self
-    directive = directive.replace("self", "'self'")
-    # Replace the equals affectation character by a space
-    directive = directive.replace("=", " ")
-    # Remove parenthesis
-    directive = directive.replace("(", "").replace(")", "")
-    # Add the current directive to the collection
-    feature_policy_directives.append(directive)
-# Convert the collection of directives to a string with ; as directives separator
-feature_policy = "; ".join(feature_policy_directives)
-print(feature_policy)
-```
-
-💻 Execution example:
-
-```shell
-$ python code.py
-fullscreen 'none'; geolocation 'self' https://game.com https://map.example.com; gyroscope 'self'; usb *
-```
-
-### Test locally a Content-Security-Policy for weaknesses
-
-It can be interesting to validate locally a **Content-Security-Policy** for presence of weaknesses prior to apply it on deployed web applications.
-
-The following _JavaScript_ code snippet can be useful to achieve such validation by leveraging the [csp-evaluator](https://github.com/google/csp-evaluator) NPM module provided by Google.
-
-💻 Code snippet:
-
-```javascript
-import {CspEvaluator} from "csp_evaluator/dist/evaluator.js";
-import {CspParser} from "csp_evaluator/dist/parser.js";
-
-const args = process.argv.slice(2)
-if(args.length == 0){
-    console.error("[!] Missing CSP!");
-}else{
-    const csp = args[0]
-    console.info(`[+] CSP to evaluate:\n${csp}`);
-    const parsed = new CspParser(csp).csp;
-    console.info(`[+] Evaluation results:`);
-    const results = new CspEvaluator(parsed).evaluate();
-    results.forEach(elt => {
-        let info = `[Directive '${elt.directive}' - Severity ${elt.severity}]: ${elt.description}`;
-        console.info(info);
-    });
-}
-```
-
-💻 Execution example:
-
-```shell
-$ node code.js "default-src 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content"
-[+] CSP to evaluate:
-default-src 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content
-[+] Evaluation results:
-[Directive 'default-src' - Severity 50]: 'self' can be problematic if you host JSONP, Angular or user uploaded files.
-```


### PR DESCRIPTION
Hi,

This PR performs the following updates:

* I removed the REST API line for the explanation specified [here](https://github.com/oshp/oshp-tracking/discussions/6#discussioncomment-4620641):

![image](https://user-images.githubusercontent.com/1573775/211160843-53a0692c-715c-4216-ad0e-5fa7bb6d2f34.png)

![image](https://user-images.githubusercontent.com/1573775/211189673-9a1a933c-ed8f-41b9-aff8-2e4df1f848c0.png)

* I added a sub menu to allow to directly reach a wanted language section for the libraries:

![image](https://user-images.githubusercontent.com/1573775/211189637-09913b2b-d779-4ee2-b8b0-eb4531068f3f.png)

* I moved the code snippets into a dedicated tab:

![image](https://user-images.githubusercontent.com/1573775/211189657-d6489cd2-0600-493b-a752-cbf341735d57.png)

Thanks in advance 😃 