### PR TITLE
Work on integration with OpenCRE OWASP project

### DIFF
--- a/tab_bestpractices.md
+++ b/tab_bestpractices.md
@@ -15,9 +15,7 @@ tags: headers
 
 ## Configuration proposal
 
-<a name=configuration-proposal-anchor></a>
-
-<div id=configuration-proposal-anchor class="ruletitle"></div>
+<!-- <div id=configuration-proposal-anchor class="ruletitle"></div> -->
 
 Please note the best practices below suggest methods to change web server configuration to add headers. Security headers can also be successfully added to your application at the software level as well in almost every web language. Many web frameworks add some of these headers automatically.
 
@@ -64,9 +62,7 @@ This section indicates the syntax to use to set an HTTP header according to the 
 
 ## Prevent information disclosure via HTTP headers
 
-<a name=prevent-information-disclosure-via-http-headers-anchor></a>
-
-<div id=prevent-information-disclosure-via-http-headers-anchor class="ruletitle"></div>
+<!-- <div id=prevent-information-disclosure-via-http-headers-anchor class="ruletitle"></div> -->
 
 This section provides a collection of HTTP response headers to remove, when possible, from any HTTP response to prevent any [disclosure of technical information](https://cwe.mitre.org/data/definitions/200.html) about environment. The following list of headers can be used to configure a [reverse proxy](https://www.nginx.com/resources/glossary/reverse-proxy-server/) or a [web application firewall](https://en.wikipedia.org/wiki/Web_application_firewall) to handle removal operation of the mentioned headers.
 

--- a/tab_bestpractices.md
+++ b/tab_bestpractices.md
@@ -15,7 +15,7 @@ tags: headers
 
 ## Configuration proposal
 
-<!-- <div id=configuration-proposal-anchor class="ruletitle"></div> -->
+<!-- <div id=div-bestpractices class="ruletitle"></div> -->
 
 Please note the best practices below suggest methods to change web server configuration to add headers. Security headers can also be successfully added to your application at the software level as well in almost every web language. Many web frameworks add some of these headers automatically.
 
@@ -62,7 +62,7 @@ This section indicates the syntax to use to set an HTTP header according to the 
 
 ## Prevent information disclosure via HTTP headers
 
-<!-- <div id=prevent-information-disclosure-via-http-headers-anchor class="ruletitle"></div> -->
+<!-- <div id=div-bestpractices class="ruletitle"></div> -->
 
 This section provides a collection of HTTP response headers to remove, when possible, from any HTTP response to prevent any [disclosure of technical information](https://cwe.mitre.org/data/definitions/200.html) about environment. The following list of headers can be used to configure a [reverse proxy](https://www.nginx.com/resources/glossary/reverse-proxy-server/) or a [web application firewall](https://en.wikipedia.org/wiki/Web_application_firewall) to handle removal operation of the mentioned headers.
 


### PR DESCRIPTION
Work on this topic: https://github.com/OWASP/common-requirement-enumeration/issues/251

Due to the way in which the HTML is rendered, I must use HTML comment to add the `<div>` for OpenCRE ref:

![image](https://user-images.githubusercontent.com/1573775/215295769-666924a3-63c2-4352-b722-5c52c1edf2e3.png)

So it's a second try...
