### PR TITLE
Try to fix table rendering issue - round 3

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@ layout: col-sidebar
 tags: headers
 ---
 
-<link rel="stylesheet" href="{{site.base_url}}/assets/css/styles.css">
+<link rel="stylesheet" href="assets/css/styles.css">
 
 ## Introduction
 


### PR DESCRIPTION
Hi,

New round for **Point C** of https://github.com/oshp/oshp-tracking/issues/16 😃  

Based on the result of the previous PR, I fixed the location of the CSS to its correct relative path on the OSHP website:

![image](https://user-images.githubusercontent.com/1573775/224904996-9e9c35fb-f5ec-4739-84eb-9f484bedb235.png)


Thanks in advance 😃 