### PR TITLE
Try to add a direct section linker.

### DIFF
--- a/assets/js/direct-link-handler.js
+++ b/assets/js/direct-link-handler.js
@@ -1,0 +1,43 @@
+/* Script to allow to direct link a section (header) into a tab (div). */
+function handleDirectLink() {
+    if (window.location.hash) {
+        //Format expected is [TAB-ID]_[HEADER-ID-INSIDE-TAB]
+        let directLocationRef = window.location.hash;
+        const validationRegex = new RegExp("^#[a-z0-9\-]{1,100}_[a-z0-9\-]{1,100}$");
+        //Ensure that the directLink respect the syntax
+        if (validationRegex.test(directLocationRef)) {
+            directLocationRef = directLocationRef.substring(1);//Remove the starting dash character
+            let parts = directLocationRef.split("_");
+            let tabLocation = parts[0].substring(4) + "-link";//remove the "-div" prefix and add the "-link" suffix
+            let headerLocation = parts[1];
+            console.debug(`[DirectLinkHandler] Move to tab '${tabLocation}' on header '${headerLocation}'.`);
+            //Retrieve the target TAB that is a link to a DIV and trigger a click
+            let tabLink = document.getElementById(tabLocation)
+            if (typeof tabLink !== "undefined") {
+                tabLink.click();
+                //Now move to the target header that have a link with a href to it
+                let links = document.querySelectorAll("a");
+                let headerLink = null;
+                links.forEach(function (lnk) {
+                    if (lnk.href.endsWith(`#${headerLocation}`) && headerLink === null) {
+                        headerLink = lnk;
+                    }
+                });
+                if (headerLink !== null) {
+                    setTimeout(() => { headerLink.click(); console.debug(`[DirectLinkHandler] Move performed.`); }, "2000");
+                    console.debug(`[DirectLinkHandler] Move scheduled.`)
+                } else {
+                    console.warn(`[DirectLinkHandler] Header tag not found.`);
+                }
+            } else {
+                console.warn(`[DirectLinkHandler] Tab link not found.`);
+            }
+        } else {
+            console.warn("[DirectLinkHandler] Direct link does not match the validation regex.")
+        }
+    }
+}
+
+window.addEventListener("load", function () {
+    handleDirectLink();
+})

--- a/index.md
+++ b/index.md
@@ -7,6 +7,7 @@ layout: col-sidebar
 tags: headers
 ---
 
+<script crossorigin="anonymous" type="application/javascript" src="assets/js/direct-link-handler.js"></script>
 <link rel="stylesheet" href="assets/css/styles.css">
 
 ## Introduction


### PR DESCRIPTION
Hi,

This PR add a custom JS script that is a tentative to allow to direct link a section (header) into a tab (div).

I based it after analyzing the OWASP site template naming convention.

I tested the script locally on Chrome (last release) but to finally validate the idea or not, I need to live usage...

Thanks in advance 😃 