### PR TITLE
Add form-action

### DIFF
--- a/tab_bestpractices.md
+++ b/tab_bestpractices.md
@@ -36,7 +36,7 @@ The following section proposes a configuration for the [actively supported and w
 | Strict-Transport-Security                    | `max-age=31536000 ; includeSubDomains` |
 | X-Frame-Options                              | `deny` |
 | X-Content-Type-Options                       | `nosniff` |
-| Content-Security-Policy                      | `default-src 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content` |
+| Content-Security-Policy                      | `default-src 'self'; form-action 'self'; object-src 'none'; frame-ancestors 'none'; upgrade-insecure-requests; block-all-mixed-content` |
 | X-Permitted-Cross-Domain-Policies            | `none` |
 | Referrer-Policy                              | `no-referrer`  |
 | Clear-Site-Data                              | `"cache","cookies","storage"` |


### PR DESCRIPTION
Hi,

This PR add the [form-action](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action) directive to the CSP proposed because, as this directive does not default to *default-src*, it can be used to bypass a CSP:

![image](https://github.com/OWASP/www-project-secure-headers/assets/1573775/443ac481-9cd2-4868-be3e-7f52496efad6)

![image](https://github.com/OWASP/www-project-secure-headers/assets/1573775/cda8af92-9dbd-44c8-bac9-250a36ad8d0f)

Tool: https://csp-evaluator.withgoogle.com/
