### PR TITLE
Add ref to "how to" linking system in the main tab

### DIFF
--- a/index.md
+++ b/index.md
@@ -61,7 +61,7 @@ tags: headers
 * It is automatically deployed on `https://oshp-validator-mock.onrender.com`
 * Technical details about this endpoint are [here](https://github.com/oshp/oshp-validator#tests-suite-mock-service).
 
-## Headers reference files
+## Security headers reference files
 
 📖 As mentioned in previous sections, we provide the collection of HTTP response security headers to add as well as HTTP response headers to remove, both in table form.
 
@@ -85,6 +85,10 @@ tags: headers
 ## Notification of update
 
 📡 This [atom web feed](https://github.com/OWASP/www-project-secure-headers/commits/master.atom) can be used to be notified when an update is pushed on the OSHP website's repository.
+
+## Create a link to the OSHP site
+
+📖 This is documented into the **[Case Studies](https://owasp.org/www-project-secure-headers/index.html#div-casestudies)** tab.
 
 ## Contributors
 

--- a/tab_casestudies.md
+++ b/tab_casestudies.md
@@ -58,6 +58,7 @@ https://owasp.org/www-project-secure-headers/index.html#div-technical_php
 * [Zoom](https://developers.zoom.us/docs/zoom-apps/security/owasp/).
 * [NexusGuard](https://blog.nexusguard.com/hardening-web-applications-using-secure-http-headers).
 * [VeraCode](https://docs.veracode.com/r/enable-security-headers).
+* [Ivanti](https://forums.ivanti.com/s/article/HTTP-Security-Headers-X-Frame-Options-X-XSS-Protection-X-Content-Type-Options).
 
 ## Software
 


### PR DESCRIPTION
Hi,

This PR handle this point: https://github.com/oshp/oshp-tracking/issues/27

It also add a new company referencing the OSHP: [Ivanti](https://forums.ivanti.com/s/article/HTTP-Security-Headers-X-Frame-Options-X-XSS-Protection-X-Content-Type-Options)

Thanks in advance 😀
