### PR TITLE
Remove unmaintained lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@
 
 ## Automatically generated content
 
+> [!TIP]
+> 🔬[Technical References Dashboard](monitoring_technical_references_dashboard.md).
+
 🏭 The folder [ci](ci) (**CI** for **C**ontinuous **I**ntegration) contains materials to generate the following content.
 
 📝 Generation of the both JSON files containing the header recommended to add and remove:

--- a/tab_technical.md
+++ b/tab_technical.md
@@ -51,7 +51,6 @@ tags: headers
 
 | Library | Description | Ref |
 | --- | --- | --- |
-| **NWebsec** | NWebsec consists of several security libraries for ASP.NET applications. | [👩‍💻](https://github.com/NWebsec/NWebsec) |
 | **NetEscapades.AspNetCore.SecurityHeaders** | Small package to allow adding security headers to ASP.NET Core websites. | [👩‍💻](https://github.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders) |
 | **OwaspHeaders.Core** | .NET Core middleware for injecting the OWASP recommended HTTP Headers for increased security | [👩‍💻](https://github.com/GaProgMan/OwaspHeaders.Core) |
 


### PR DESCRIPTION
Hi,

This PR:
* Add a quick shortcut to the **[Technical References Dashboard](https://github.com/OWASP/www-project-secure-headers/blob/master/monitoring_technical_references_dashboard.md)** generated.
* Remove the lib [NWebsec](https://github.com/NWebsec/NWebsec) as it has reached the limit of *no update* threshold:

![image](https://github.com/user-attachments/assets/7c004d9c-1b42-451d-b320-68f29390cba5)

Thanks in advance 😀.
