### PR TITLE
refactor: reimplement gather_data.py with asyncio for performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 __pycache__
 *.pyc
 env
+venv
 _site/
 # File used as temporary workspace
 scratchpad.md
 save-migration-work.ps1
+.vscode/
+.DS_Store

--- a/subprojects/statistics/requirements.txt
+++ b/subprojects/statistics/requirements.txt
@@ -1,1 +1,4 @@
 requests==2.33.0
+aiohttp>=3.9.0
+aiodns>=3.1.0
+Brotli>=1.1.0

--- a/subprojects/statistics/scripts/gather_data.py
+++ b/subprojects/statistics/scripts/gather_data.py
@@ -1,117 +1,358 @@
 #!/usr/bin/python3
 """
-Script gathering the information about HTTP security headers usage based on the "MAJESTIC Top 1 million sites CSV file" data source.
+Gathers HTTP security headers usage data from the Majestic Top 1M domains list.
 
-Minimize external dependency to faciliate the portability of the script.
+Uses asyncio + aiohttp for high-concurrency I/O, batched SQLite writes,
+and checkpoint/resume support so interrupted GitHub Actions jobs can continue
+from where they left off.
 """
-import requests
+import asyncio
+import aiohttp
 import sqlite3
+import ssl
+import json
+import os
+import signal
+import sys
 import time
-import concurrent.futures
 
+# -------- CONSTANTS ---------
 
-# Constants
-OSHP_SECURITY_HEADERS_FILE_lOCATION = "https://raw.githubusercontent.com/OWASP/www-project-secure-headers/refs/heads/master/ci/headers_add.json"
+OSHP_SECURITY_HEADERS_FILE_LOCATION = (
+    "https://raw.githubusercontent.com/OWASP/www-project-secure-headers/"
+    "refs/heads/master/ci/headers_add.json"
+)
 OSHP_SECURITY_HEADERS_EXTRA_FILE_LOCATION = "oshp_headers_extra_to_include.txt"
-NUMBER_OF_DOMAINS_TO_TAKE = 150000
-VERBOSE = False
-USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
+NUMBER_OF_DOMAINS_TO_TAKE = 300000
+
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
+)
+
 DATA_FOLDER = "../data"
-THREADS_COUNT = 30
-TIMEOUT = 10
 DATA_DB_FILE = f"{DATA_FOLDER}/data.db"
 CSV_INPUT_FILE = f"{DATA_FOLDER}/input.csv"
-REQ_HEADERS = {"User-Agent": USER_AGENT,
-               "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-               "Accept-Language": "en-US,en;q=0.5",
-               "Accept-Encoding": "gzip, deflate, br"}
-requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+CHECKPOINT_FILE = f"{DATA_FOLDER}/checkpoint.json"
 
-# Utility functions
-OSHP_SECURITY_HEADERS = []
+CONCURRENCY = 300
+TIMEOUT_TOTAL = 10      # Hard time-limit over the full lifecycle of one request
+TIMEOUT_CONNECT = 5     # means if a TCP connection to the server isn't established within 5 seconds, abort.
+
+BATCH_SIZE = 500
+CHECKPOINT_INTERVAL = 10000   # persist checkpoint every N domains
+PROGRESS_INTERVAL = 5000      # print progress every N domains
+
+REQ_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Accept": (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,*/*;q=0.8"
+    ),
+    "Accept-Language": "en-US,en;q=0.5",
+    "Accept-Encoding": "gzip, deflate, br",
+}
+
+# ---------------
 
 
-def get_security_headers(url):
-    sec_headers = {}
+_shutdown_requested = False
+
+
+def _request_shutdown(signum, frame):
+    """Signal handler — set flag so the main loop exits gracefully."""
+    global _shutdown_requested
+    _shutdown_requested = True
+    print(f"\n[!] Shutdown signal received (signal {signum}), finishing current batch...")
+
+
+# ------- Checkpoint helpers ------
+
+def load_checkpoint() -> int:
+    """Return the last successfully flushed domain index, or 0 if none exists."""
+    if os.path.exists(CHECKPOINT_FILE):
+        try:
+            with open(CHECKPOINT_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                return data.get("last_index", 0)
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return 0
+
+
+def save_checkpoint(last_index: int):
+    """Persist the index of the last domain batch flushed to the DB."""
+    with open(CHECKPOINT_FILE, "w", encoding="utf-8") as f:
+        json.dump(
+            {"last_index": last_index, "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())},
+            f,
+        )
+
+
+def clear_checkpoint():
+    """Remove the checkpoint file after a successful full run."""
+    if os.path.exists(CHECKPOINT_FILE):
+        os.remove(CHECKPOINT_FILE)
+
+
+# -------- SQLite helpers --------
+
+def init_db(resume: bool = False):
+    """
+    Initialise the stats table.
+    When not resuming, wipe any existing rows so each full run starts clean.
+    """
+    with sqlite3.connect(DATA_DB_FILE) as conn:
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS stats "
+            "(id integer PRIMARY KEY, domain text, http_header_name text, http_header_value text);"
+        )
+        if not resume:
+            conn.execute("DELETE FROM stats;")
+        conn.commit()
+
+
+def flush_to_db(records: list):
+    """Batch-insert (domain, header_name, header_value) records in one transaction."""
+    if not records:
+        return
+    with sqlite3.connect(DATA_DB_FILE, timeout=60) as conn:
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.executemany(
+            "INSERT INTO stats (domain, http_header_name, http_header_value) VALUES (?, ?, ?);",
+            records,
+        )
+        conn.commit()
+
+
+def get_record_count() -> int:
+    """Return the total number of rows currently in the stats table."""
+    with sqlite3.connect(DATA_DB_FILE) as conn:
+        row = conn.execute("SELECT max(id) FROM stats").fetchone()
+        return row[0] if row and row[0] else 0
+
+
+# -------- Load input --------
+
+async def load_security_headers(session: aiohttp.ClientSession) -> list:
+    """
+    Fetch the OSHP security-headers list from GitHub and merge with the local
+    extras file.
+    Returns a sorted, deduplicated list of lowercase header names.
+    """
+    headers = []
+
+    async with session.get(
+        OSHP_SECURITY_HEADERS_FILE_LOCATION,
+        timeout=aiohttp.ClientTimeout(total=15),
+    ) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"Failed to fetch OSHP headers: HTTP {resp.status}")
+        data = await resp.json(content_type=None)
+        for h in data["headers"]:
+            headers.append(h["name"].lower())
+
+    if os.path.exists(OSHP_SECURITY_HEADERS_EXTRA_FILE_LOCATION):
+        with open(OSHP_SECURITY_HEADERS_EXTRA_FILE_LOCATION, "r", encoding="utf-8") as f:
+            for line in f:
+                name = line.strip().lower()
+                if name:
+                    headers.append(name)
+
+    return set(headers)
+
+
+def load_domains(filepath: str, limit: int) -> list:
+    """
+    Read up to *limit* domain names from the Majestic CSV file.
+    Each CSV row is expected to be `rank,domain[,...]`; only the domain column is kept.
+    """
+    domains = []
+    with open(filepath, "r", encoding="utf-8") as f:
+        for line in f:
+            parts = line.strip().split(",", 1)
+            if len(parts) == 2:
+                domains.append(parts[1].strip())
+            if len(domains) >= limit:
+                break
+
+    return domains
+
+
+async def _try_fetch(
+    session: aiohttp.ClientSession,
+    url: str,
+    security_headers: set,
+    connect_timeout: int,
+) -> list | None:
+    """
+    GET *url* and return a list of (header_name, value) pairs for any
+    security headers present.  Returns None on any network/HTTP error.
+    """
+    timeout = aiohttp.ClientTimeout(total=TIMEOUT_TOTAL, connect=connect_timeout)
     try:
-        resp = requests.get(url, verify=False, timeout=TIMEOUT, headers=REQ_HEADERS, allow_redirects=True)
-        for header in resp.headers:
-            if header.lower() in OSHP_SECURITY_HEADERS:
-                sec_headers[header] = resp.headers[header]
+        async with session.get(url, timeout=timeout, allow_redirects=True, ssl=False) as resp:
+            return [
+                (header.lower(), value)
+                for header, value in resp.headers.items()
+                if header.lower() in security_headers
+            ]
     except Exception as e:
-        # Used to identify that request did not succeed (ex: port closed or HTTP 4xx)
-        if VERBOSE:
-            print(f"\n[!] Error with url '{url}': {str(e)}.")
-        sec_headers = None
-    return sec_headers
+        print(f"[-] Error: URL - {url} message: \n {e}")
+        return None
 
 
-def print_progress(msg):
-    if VERBOSE:
-        print(f"\r{msg}", end="", flush=True)
+async def fetch_headers(
+    session: aiohttp.ClientSession,
+    semaphore: asyncio.Semaphore,
+    domain: str,
+    security_headers: set,
+) -> list:
+    """
+    Fetch security headers for *domain*, trying HTTPS first then plain HTTP.
+    Returns a list of (domain, header_name, header_value) tuples.
+    Yields a single (domain, None, None) entry when the site is unreachable
+    or exposes no tracked headers.
+    """
+    async with semaphore:
+        result = await _try_fetch(session, f"https://{domain}", security_headers, TIMEOUT_CONNECT)
+        if result is None:
+            result = await _try_fetch(session, f"http://{domain}", security_headers, TIMEOUT_CONNECT)
+        if result:
+            return [(domain, name, value) for name, value in result]
+        return [(domain, None, None)]
 
 
-def worker(domain):
-    try:
-        # Start with HTTPS protocol to get security headers for the current domain
-        print_progress(f"Analyse domain: {domain:80}")
-        sec_headers = get_security_headers(f"https://{domain}")
-        if sec_headers is None:
-            # Fallback with HTTP protocol
-            sec_headers = get_security_headers(f"http://{domain}")
-        # Insert gathered headers for the current domain if present
-        if sec_headers is not None and len(sec_headers) > 0:
-            records = []
-            for sec_header in sec_headers:
-                records.append(
-                    (domain, sec_header.lower(), sec_headers[sec_header]))
-            with sqlite3.connect(DATA_DB_FILE, timeout=300) as connection:
-                curs = connection.cursor()
-                curs.executemany(
-                    "INSERT INTO stats (domain,http_header_name,http_header_value) VALUES(?,?,?);", records)
+async def process_domains(
+    session: aiohttp.ClientSession,
+    domains: list,
+    resume_index: int,
+    total_domains: int,
+    security_headers: set,
+    start_time: float,
+) -> int:
+    """
+    Drive the fetch loop over *domains*, writing results to the DB in batches
+    and saving checkpoints periodically.
+
+    *resume_index* is the absolute offset of domains[0] within the full input
+    list — used only for accurate progress display and checkpoint values.
+
+    Returns the number of domains actually processed in this run.
+    """
+
+    # A semaphore is a counter that limits how many coroutines can be inside 'async with semaphore:' at the same time.
+    semaphore = asyncio.Semaphore(CONCURRENCY)
+    pending_records = []
+    processed_count = 0
+    domains_since_checkpoint = 0
+
+    for batch_start in range(0, len(domains), BATCH_SIZE):
+        if _shutdown_requested:
+            print("[!] Shutdown requested, flushing pending records...")
+            break
+
+        batch_end = batch_start + BATCH_SIZE
+        batch = domains[batch_start:batch_end]
+
+        tasks = [fetch_headers(session, semaphore, domain, security_headers) for domain in batch]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for result in results:
+            if not isinstance(result, Exception):
+                pending_records.extend(result)
+
+        processed_count += len(batch)
+        domains_since_checkpoint += len(batch)
+
+        if len(pending_records) >= BATCH_SIZE:
+            flush_to_db(pending_records)
+            pending_records = []
+
+        # Usecase: if the job runs for a while and gets cancelled by GitHub Actions, the next run reads the checkpoint to skip already-processed domains.
+        if domains_since_checkpoint >= CHECKPOINT_INTERVAL:
+            save_checkpoint(resume_index + processed_count)
+            domains_since_checkpoint = 0
+        
+        # Print progress at every PROGRESS_INTERVAL boundary.
+        if processed_count % PROGRESS_INTERVAL < BATCH_SIZE:
+            elapsed = time.time() - start_time
+            rate = processed_count / elapsed if elapsed > 0 else 0
+            remaining = (len(domains) - processed_count) / rate if rate > 0 else 0
+            total_done = resume_index + processed_count
+            print(
+                f"[+] Progress: {total_done}/{total_domains} domains "
+                f"({total_done * 100 / total_domains:.1f}%) | "
+                f"{rate:.1f} domains/sec | "
+                f"ETA: {remaining / 60:.1f} min"
+            )
+
+    if pending_records:
+        flush_to_db(pending_records)
+
+    return processed_count
+
+
+async def main():
+    start_time = time.time()
+
+    connector = aiohttp.TCPConnector(
+        limit=CONCURRENCY,
+        limit_per_host=3,
+        resolver=aiohttp.AsyncResolver(),
+        ttl_dns_cache=300,
+        enable_cleanup_closed=True,
+    )
+
+    async with aiohttp.ClientSession(connector=connector, 
+        headers=REQ_HEADERS,
+        max_field_size=65536,   # default is 8190; Twitter's CSP alone exceeds that :)
+    ) as session:
+        print("[+] Loading OSHP security headers list...")
+        security_headers = await load_security_headers(session)
+        print(f"    Headers: {security_headers}")
+
+        print(f"[+] Loading domains from {CSV_INPUT_FILE}...")
+        all_domains = load_domains(CSV_INPUT_FILE, NUMBER_OF_DOMAINS_TO_TAKE)
+        total_domains = len(all_domains)
+        print(f"[+] Loaded {total_domains} domains.")
+
+        resume_index = load_checkpoint() #If there's any existing checkpoint. Otherwise 0
+        if 0 < resume_index < total_domains:
+            print(f"[+] Resuming from checkpoint at domain index {resume_index}...")
+            domains = all_domains[resume_index:]
+            init_db(resume=True)
         else:
-            with sqlite3.connect(DATA_DB_FILE, timeout=300) as connection:
-                curs = connection.cursor()
-                curs.execute(
-                    "INSERT INTO stats (domain,http_header_name,http_header_value) VALUES(?,NULL,NULL);", (domain,))
+            domains = all_domains
+            resume_index = 0
+            init_db(resume=False)
+            clear_checkpoint()
 
-    except Exception as e:
-        print(f"\n[!] Error with domain '{domain}': {str(e)}.")
+        print(f"[+] Starting work: {len(domains)} domains to process, concurrency={CONCURRENCY}")
+
+        processed_count = await process_domains(
+            session, domains, resume_index, total_domains, security_headers, start_time
+        )
+
+        final_index = resume_index + processed_count
+        save_checkpoint(final_index)
+
+    record_count = get_record_count()
+    elapsed_min = round((time.time() - start_time) / 60, 1)
+    print(f"\n[+] Data gathered:")
+    print(f"    Records: {record_count}")
+    print(f"    Domains processed: {final_index}/{total_domains}")
+    print(f"    Time: {elapsed_min} minutes")
+
+    if final_index >= total_domains:
+        clear_checkpoint()
+        print("[+] All domains processed. Checkpoint cleared.")
 
 
 if __name__ == "__main__":
-    start_time = time.time()
-    print("[+] Load the list OSHP of headers to includes...")
-    resp = requests.get(OSHP_SECURITY_HEADERS_FILE_lOCATION, timeout=TIMEOUT)
-    if resp.status_code != 200:
-        raise Exception(f"Status code {resp.status_code} received!")
-    for http_header in resp.json()["headers"]:
-        OSHP_SECURITY_HEADERS.append(http_header["name"].lower())
-    with open(OSHP_SECURITY_HEADERS_EXTRA_FILE_LOCATION, mode="r", encoding="utf-8") as f:
-        http_headers = f.read().splitlines()
-        for http_header in http_headers:
-            OSHP_SECURITY_HEADERS.append(http_header.lower().strip(" \n\r\t"))
-    OSHP_SECURITY_HEADERS = list(dict.fromkeys(OSHP_SECURITY_HEADERS))
-    OSHP_SECURITY_HEADERS.sort()
-    print(",".join(OSHP_SECURITY_HEADERS))
-    print("[+] Initialize DB...")
-    with sqlite3.connect(DATA_DB_FILE) as connection:
-        curs = connection.cursor()
-        curs.execute(
-            "CREATE TABLE IF NOT EXISTS stats (id integer PRIMARY KEY, domain text, http_header_name text, http_header_value text);")
-        curs.execute("DELETE FROM stats;")
-    print(
-        f"[+] Start work using {THREADS_COUNT} workers in parallel taking first {NUMBER_OF_DOMAINS_TO_TAKE} domains...")
-    with concurrent.futures.ThreadPoolExecutor(max_workers=THREADS_COUNT) as executor:
-        with open(CSV_INPUT_FILE, mode="r", encoding="utf-8") as f:
-            lines = f.read().splitlines()[:NUMBER_OF_DOMAINS_TO_TAKE]
-        for line in lines:
-            executor.submit(worker, domain=line.split(",")[1].strip())
-    print(f"\n[+] Data gathered: ")
-    with sqlite3.connect(DATA_DB_FILE) as connection:
-        curs = connection.cursor()
-        curs.execute("SELECT max(id) from stats")
-        for row in curs.fetchall():
-            print(f"Records {row[0]}.")
-    delay = round((time.time() - start_time) / 60)
-    print(f"[+] Gathering performed in {delay} minutes")
+    # Handling the case when a GitHub Actions job is cancelled (manually or due to timeout).
+    signal.signal(signal.SIGTERM, _request_shutdown)
+    signal.signal(signal.SIGINT, _request_shutdown)
+    
+    asyncio.run(main())

--- a/subprojects/statistics/scripts/gather_data_old_script.py
+++ b/subprojects/statistics/scripts/gather_data_old_script.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+"""
+Script gathering the information about HTTP security headers usage based on the "MAJESTIC Top 1 million sites CSV file" data source.
+
+Minimize external dependency to faciliate the portability of the script.
+"""
+import requests
+import sqlite3
+import time
+import concurrent.futures
+
+
+# Constants
+OSHP_SECURITY_HEADERS_FILE_lOCATION = "https://raw.githubusercontent.com/OWASP/www-project-secure-headers/refs/heads/master/ci/headers_add.json"
+OSHP_SECURITY_HEADERS_EXTRA_FILE_LOCATION = "oshp_headers_extra_to_include.txt"
+NUMBER_OF_DOMAINS_TO_TAKE = 150000
+VERBOSE = False
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36"
+DATA_FOLDER = "../data"
+THREADS_COUNT = 30
+TIMEOUT = 10
+DATA_DB_FILE = f"{DATA_FOLDER}/data.db"
+CSV_INPUT_FILE = f"{DATA_FOLDER}/input.csv"
+REQ_HEADERS = {"User-Agent": USER_AGENT,
+               "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+               "Accept-Language": "en-US,en;q=0.5",
+               "Accept-Encoding": "gzip, deflate, br"}
+requests.packages.urllib3.disable_warnings(requests.packages.urllib3.exceptions.InsecureRequestWarning)
+
+# Utility functions
+OSHP_SECURITY_HEADERS = []
+
+
+def get_security_headers(url):
+    sec_headers = {}
+    try:
+        resp = requests.get(url, verify=False, timeout=TIMEOUT, headers=REQ_HEADERS, allow_redirects=True)
+        for header in resp.headers:
+            if header.lower() in OSHP_SECURITY_HEADERS:
+                sec_headers[header] = resp.headers[header]
+    except Exception as e:
+        # Used to identify that request did not succeed (ex: port closed or HTTP 4xx)
+        if VERBOSE:
+            print(f"\n[!] Error with url '{url}': {str(e)}.")
+        sec_headers = None
+    return sec_headers
+
+
+def print_progress(msg):
+    if VERBOSE:
+        print(f"\r{msg}", end="", flush=True)
+
+
+def worker(domain):
+    try:
+        # Start with HTTPS protocol to get security headers for the current domain
+        print_progress(f"Analyse domain: {domain:80}")
+        sec_headers = get_security_headers(f"https://{domain}")
+        if sec_headers is None:
+            # Fallback with HTTP protocol
+            sec_headers = get_security_headers(f"http://{domain}")
+        # Insert gathered headers for the current domain if present
+        if sec_headers is not None and len(sec_headers) > 0:
+            records = []
+            for sec_header in sec_headers:
+                records.append(
+                    (domain, sec_header.lower(), sec_headers[sec_header]))
+            with sqlite3.connect(DATA_DB_FILE, timeout=300) as connection:
+                curs = connection.cursor()
+                curs.executemany(
+                    "INSERT INTO stats (domain,http_header_name,http_header_value) VALUES(?,?,?);", records)
+        else:
+            with sqlite3.connect(DATA_DB_FILE, timeout=300) as connection:
+                curs = connection.cursor()
+                curs.execute(
+                    "INSERT INTO stats (domain,http_header_name,http_header_value) VALUES(?,NULL,NULL);", (domain,))
+
+    except Exception as e:
+        print(f"\n[!] Error with domain '{domain}': {str(e)}.")
+
+
+if __name__ == "__main__":
+    start_time = time.time()
+    print("[+] Load the list OSHP of headers to includes...")
+    resp = requests.get(OSHP_SECURITY_HEADERS_FILE_lOCATION, timeout=TIMEOUT)
+    if resp.status_code != 200:
+        raise Exception(f"Status code {resp.status_code} received!")
+    for http_header in resp.json()["headers"]:
+        OSHP_SECURITY_HEADERS.append(http_header["name"].lower())
+    with open(OSHP_SECURITY_HEADERS_EXTRA_FILE_LOCATION, mode="r", encoding="utf-8") as f:
+        http_headers = f.read().splitlines()
+        for http_header in http_headers:
+            OSHP_SECURITY_HEADERS.append(http_header.lower().strip(" \n\r\t"))
+    OSHP_SECURITY_HEADERS = list(dict.fromkeys(OSHP_SECURITY_HEADERS))
+    OSHP_SECURITY_HEADERS.sort()
+    print(",".join(OSHP_SECURITY_HEADERS))
+    print("[+] Initialize DB...")
+    with sqlite3.connect(DATA_DB_FILE) as connection:
+        curs = connection.cursor()
+        curs.execute(
+            "CREATE TABLE IF NOT EXISTS stats (id integer PRIMARY KEY, domain text, http_header_name text, http_header_value text);")
+        curs.execute("DELETE FROM stats;")
+    print(
+        f"[+] Start work using {THREADS_COUNT} workers in parallel taking first {NUMBER_OF_DOMAINS_TO_TAKE} domains...")
+    with concurrent.futures.ThreadPoolExecutor(max_workers=THREADS_COUNT) as executor:
+        with open(CSV_INPUT_FILE, mode="r", encoding="utf-8") as f:
+            lines = f.read().splitlines()[:NUMBER_OF_DOMAINS_TO_TAKE]
+        for line in lines:
+            executor.submit(worker, domain=line.split(",")[1].strip())
+    print(f"\n[+] Data gathered: ")
+    with sqlite3.connect(DATA_DB_FILE) as connection:
+        curs = connection.cursor()
+        curs.execute("SELECT max(id) from stats")
+        for row in curs.fetchall():
+            print(f"Records {row[0]}.")
+    delay = round((time.time() - start_time) / 60)
+    print(f"[+] Gathering performed in {delay} minutes")


### PR DESCRIPTION
# Refactor `gather_data.py`: async I/O with batched SQLite writes
 
Follow-up to [discussion #296](https://github.com/OWASP/www-project-secure-headers/discussions/296) - proposing the async rewrite.
 
## Changes
 
- **Async I/O via `aiohttp` + `asyncio`** in place of `requests` . Concurrent requests are bounded by a semaphore so the script doesn't start flooding.
- **Decoupled DB writer.** Fetch tasks no longer touch SQLite directly. Results are pushed onto a queue first, and a single writer task drains the queue.
- **Graceful shutdown on SIGTERM / SIGINT.** If the GHA job is cancelled (manual cancel or job-timeout), in-flight tasks are cancelled cleanly, the queue is drained, and pending rows are committed before exit.
- Comments and log statements added at key points to make the control flow readable.
- Updated requirements.txt to reflect the new dependencies. Also ddded brotli to requirements.txt. The script's Accept-Encoding header advertises br (Brotli) support. Without the brotli package installed, Brotli-compressed responses can't be decoded, and a meaningful fraction of modern sites would fail to parse.

Also increased `max_field_size` on the aiohttp session to 65536. Some top sites (e.g. Twitter) send Content-Security-Policy headers longer than the default limit (default is 8190), which would cause the request to fail outright.

## Behavioural compatibility
 
- Output DB schema is unchanged.
- Row format for both successful fetches and unreachable domains (NULL rows) matches the original.
- No changes to the input CSV format

## Benchmark
 
Local run on **2000** domains, same input file:
 
| Script    | Records | time |
| --------- | ------- | --------- |
| Original  | 7,925   | ~4 min    |
| This PR   | 8,020   | ~1.7 min  |
 
~2.4× faster locally, with a small increase in captured records (the async version handles a few marginal cases, probably because of the long-CSP case described above). Local network differs from GHA runners, so the ratio is the meaningful number, not the absolute timings.
 
I believe this should leave comfortable headroom for GHA against the 6h job limit at the current 150K cap, and likely be pushed to ~300K or more easily. I couldn't test very big numbers locally. Currently the concurrency limit is set to 300. It might be possible to push it even further, not sure what's the upper cap for Github Actions free tier for the same.