### PR TITLE
Add DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![OSHP Logo](mainsite/assets/images/oshp_logo.png)
 
-[![OWASP Production](https://img.shields.io/badge/owasp-production%20project-800080.svg)](https://www.owasp.org/projects)
+[![OWASP Production](https://img.shields.io/badge/owasp-production%20project-800080.svg)](https://www.owasp.org/projects) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OWASP/www-project-secure-headers)
 
 # Introduction
 

--- a/mainsite/00_index.md
+++ b/mainsite/00_index.md
@@ -6,7 +6,7 @@
 
 ![OSHP Logo](assets/images/oshp_logo.png)
 
-[![OWASP Production](https://img.shields.io/badge/owasp-production%20project-800080.svg)](https://www.owasp.org/projects)
+[![OWASP Production](https://img.shields.io/badge/owasp-production%20project-800080.svg)](https://www.owasp.org/projects) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/righettod/toolbox-pentest-web)
 
 🎯 The **OWASP Secure Headers Project** (also called **OSHP**) describes HTTP response headers that your application can use to increase the security of your application. Once set, these HTTP response headers can restrict modern browsers from running into easily preventable vulnerabilities. The OWASP Secure Headers Project intends to raise awareness and use of these headers.
 

--- a/mainsite/README.md
+++ b/mainsite/README.md
@@ -1,6 +1,9 @@
 > [!NOTE]
 > This is the main content of the OSHP following the migration of the OWASP foundation to its new CMS. See [here](https://github.com/OWASP/www-project-secure-headers/discussions/273) for all the details.
 
+> [!TIP]
+> [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/OWASP/www-project-secure-headers)
+
 * [Index](00_index.md)
 * [Response Headers](01_headers.md)
 * [Browser Support](02_browser_support.md)


### PR DESCRIPTION
Hi,

This PR add the link to the page on `DeepWiki.com` for the OSHP via a dedicated badge:

[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/righettod/toolbox-pentest-web)

https://deepwiki.com/OWASP/www-project-secure-headers

💡 It is particularly relevant now as all the OSHP content is markdown based and centralized in a single GH repo.

Thanks in advance 😀
