### PR TITLE
Fix millisecond timeout parsing in link checker

### DIFF
--- a/ci/validate_md_links.py
+++ b/ci/validate_md_links.py
@@ -72,7 +72,13 @@ def load_config(markdown_link_check_config_file_path):
     if "timeout" not in cfg:
         cfg["timeout"] = DEFAULT_TIMEOUT_IN_SECONDS
     else:
-        cfg["timeout"] = int(cfg["timeout"].strip("ms"))
+        timeout = cfg["timeout"].strip()
+        if timeout.endswith("ms"):
+            cfg["timeout"] = float(timeout[:-2]) / 1000
+        elif timeout.endswith("s"):
+            cfg["timeout"] = float(timeout[:-1])
+        else:
+            cfg["timeout"] = float(timeout)
     if "retryCount" not in cfg:
         cfg["retryCount"] = DEFAULT_RETRY_COUNT
     if "aliveStatusCodes" not in cfg:

--- a/tests/test_validate_md_links.py
+++ b/tests/test_validate_md_links.py
@@ -1,0 +1,29 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+from validate_md_links import load_config
+
+
+class LoadConfigTest(unittest.TestCase):
+    def load_timeout(self, timeout):
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = Path(directory) / "config.json"
+            config_path.write_text(json.dumps({"timeout": timeout}), encoding="utf-8")
+            config = load_config(config_path)
+            self.addCleanup(config["req_session"].close)
+            return config["timeout"]
+
+    def test_parses_timeout_in_seconds(self):
+        self.assertEqual(60, self.load_timeout("60s"))
+
+    def test_converts_timeout_in_milliseconds_to_seconds(self):
+        self.assertEqual(1.5, self.load_timeout("1500ms"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi,

This fixes timeout parsing in the standalone Markdown link checker.

`markdown-link-check` accepts timeouts in milliseconds as well as seconds, but `load_config()` previously stripped the unit and interpreted `1500ms` as 1,500 seconds. The updated parser converts millisecond values to seconds while preserving second-based and unitless configurations.

The PR also adds focused standard-library regression tests for both `60s` and `1500ms`.

Validation:

* `.venv/bin/python -m unittest discover -s tests -v`
* `.venv/bin/python -m compileall -q ci tests subprojects/statistics/scripts subprojects/validator/test_suite_mock.py`
* `.venv/bin/python ./ci/validate_md_links.py -c markdown-link-check_config.json` (all links valid, exit code 0)

The change is limited to the timeout parser and its tests.

Thanks in advance 😀